### PR TITLE
[JENKINS-58461, 58458] Increase minimum required Jenkins version to 2.164.1

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,2 +1,2 @@
 _extends: .github
-tag-template: role-strategy-$NEXT_MINOR_VERSION
+tag-template: folder-auth-$NEXT_MINOR_VERSION

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,2 @@
 // Builds a module using https://github.com/jenkins-infra/pipeline-library
-buildPlugin(jenkinsVersions: [null, '2.150.2'])
+buildPlugin(configurations: buildPlugin.recommendedConfigurations())

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <properties>
         <revision>0.01</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.60.3</jenkins.version>
+        <jenkins.version>2.164.1</jenkins.version>
         <java.level>8</java.level>
         <configuration-as-code.version>1.24-rc834.e55a938c5ddd</configuration-as-code.version>
     </properties>
@@ -53,6 +53,15 @@
         </license>
     </licenses>
 
+    <scm>
+        <connection>scm:git:ssh://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+        <developerConnection>
+            scm:git:ssh://git@github.com:jenkinsci/${project.artifactId}-plugin.git
+        </developerConnection>
+        <url>https://github.com/jenkinsci/folder-auth-plugin</url>
+        <tag>${scmTag}</tag>
+    </scm>
+
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -74,5 +83,3 @@
         </dependency>
     </dependencies>
 </project>
-
-

--- a/src/main/java/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink.java
+++ b/src/main/java/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink.java
@@ -39,7 +39,7 @@ public class FolderAuthorizationStrategyManagementLink extends ManagementLink {
     @CheckForNull
     @Override
     public String getIconFileName() {
-        return Jenkins.getInstance().getAuthorizationStrategy() instanceof FolderBasedAuthorizationStrategy ?
+        return Jenkins.get().getAuthorizationStrategy() instanceof FolderBasedAuthorizationStrategy ?
                 "lock.png" : null;
     }
 
@@ -83,7 +83,7 @@ public class FolderAuthorizationStrategyManagementLink extends ManagementLink {
     @RequirePOST
     @Restricted(NoExternalUse.class)
     public void doAddGlobalRole(@JsonBody GlobalRoleCreationRequest request) throws IOException {
-        Jenkins jenkins = Jenkins.getInstance();
+        Jenkins jenkins = Jenkins.get();
         jenkins.checkPermission(Jenkins.ADMINISTER);
         AuthorizationStrategy strategy = jenkins.getAuthorizationStrategy();
         if (strategy instanceof FolderBasedAuthorizationStrategy) {
@@ -109,7 +109,7 @@ public class FolderAuthorizationStrategyManagementLink extends ManagementLink {
     @Restricted(NoExternalUse.class)
     public void doAssignSidToGlobalRole(@QueryParameter(required = true) String roleName,
                                         @QueryParameter(required = true) String sid) throws IOException {
-        Jenkins jenkins = Jenkins.getInstance();
+        Jenkins jenkins = Jenkins.get();
         jenkins.checkPermission(Jenkins.ADMINISTER);
         AuthorizationStrategy strategy = jenkins.getAuthorizationStrategy();
         if (strategy instanceof FolderBasedAuthorizationStrategy) {
@@ -131,7 +131,7 @@ public class FolderAuthorizationStrategyManagementLink extends ManagementLink {
     @RequirePOST
     @Restricted(NoExternalUse.class)
     public void doAddFolderRole(@JsonBody FolderRoleCreationRequest request) throws IOException {
-        Jenkins jenkins = Jenkins.getInstance();
+        Jenkins jenkins = Jenkins.get();
         jenkins.checkPermission(Jenkins.ADMINISTER);
         AuthorizationStrategy strategy = jenkins.getAuthorizationStrategy();
         if (strategy instanceof FolderBasedAuthorizationStrategy) {
@@ -155,7 +155,7 @@ public class FolderAuthorizationStrategyManagementLink extends ManagementLink {
     @Restricted(NoExternalUse.class)
     public void doAssignSidToFolderRole(@QueryParameter(required = true) String roleName,
                                         @QueryParameter(required = true) String sid) throws IOException {
-        Jenkins jenkins = Jenkins.getInstance();
+        Jenkins jenkins = Jenkins.get();
         jenkins.checkPermission(Jenkins.ADMINISTER);
         AuthorizationStrategy strategy = jenkins.getAuthorizationStrategy();
         if (strategy instanceof FolderBasedAuthorizationStrategy) {
@@ -180,7 +180,7 @@ public class FolderAuthorizationStrategyManagementLink extends ManagementLink {
     @Nonnull
     @Restricted(NoExternalUse.class)
     public Set<GlobalRole> getGlobalRoles() {
-        AuthorizationStrategy strategy = Jenkins.getInstance().getAuthorizationStrategy();
+        AuthorizationStrategy strategy = Jenkins.get().getAuthorizationStrategy();
         if (strategy instanceof FolderBasedAuthorizationStrategy) {
             return ((FolderBasedAuthorizationStrategy) strategy).getGlobalRoles();
         } else {
@@ -196,7 +196,7 @@ public class FolderAuthorizationStrategyManagementLink extends ManagementLink {
     @Nonnull
     @Restricted(NoExternalUse.class)
     public List<AbstractFolder> getAllFolders() {
-        Jenkins jenkins = Jenkins.getInstance();
+        Jenkins jenkins = Jenkins.get();
         jenkins.checkPermission(Jenkins.ADMINISTER);
         List<AbstractFolder> folders;
 
@@ -217,7 +217,7 @@ public class FolderAuthorizationStrategyManagementLink extends ManagementLink {
     @Nonnull
     @Restricted(NoExternalUse.class)
     public Set<FolderRole> getFolderRoles() {
-        AuthorizationStrategy strategy = Jenkins.getInstance().getAuthorizationStrategy();
+        AuthorizationStrategy strategy = Jenkins.get().getAuthorizationStrategy();
         if (strategy instanceof FolderBasedAuthorizationStrategy) {
             return ((FolderBasedAuthorizationStrategy) strategy).getFolderRoles();
         } else {
@@ -239,7 +239,7 @@ public class FolderAuthorizationStrategyManagementLink extends ManagementLink {
     @Restricted(NoExternalUse.class)
     public void doDeleteGlobalRole(@QueryParameter(required = true) String roleName)
             throws IOException {
-        Jenkins jenkins = Jenkins.getInstance();
+        Jenkins jenkins = Jenkins.get();
         jenkins.checkPermission(Jenkins.ADMINISTER);
         AuthorizationStrategy strategy = jenkins.getAuthorizationStrategy();
         if (strategy instanceof FolderBasedAuthorizationStrategy) {
@@ -263,7 +263,7 @@ public class FolderAuthorizationStrategyManagementLink extends ManagementLink {
     @Restricted(NoExternalUse.class)
     public void doDeleteFolderRole(@QueryParameter(required = true) String roleName)
             throws IOException {
-        Jenkins jenkins = Jenkins.getInstance();
+        Jenkins jenkins = Jenkins.get();
         jenkins.checkPermission(Jenkins.ADMINISTER);
         AuthorizationStrategy strategy = jenkins.getAuthorizationStrategy();
         if (strategy instanceof FolderBasedAuthorizationStrategy) {

--- a/src/main/java/io/jenkins/plugins/folderauth/FolderBasedAuthorizationStrategy.java
+++ b/src/main/java/io/jenkins/plugins/folderauth/FolderBasedAuthorizationStrategy.java
@@ -188,7 +188,7 @@ public class FolderBasedAuthorizationStrategy extends AuthorizationStrategy {
     public void addGlobalRole(@Nonnull GlobalRole globalRole) throws IOException {
         globalRoles.add(globalRole);
         try {
-            Jenkins.getInstance().save();
+            Jenkins.get().save();
         } catch (IOException e) {
             LOGGER.log(Level.SEVERE, "Unable to save config file, not adding global role", e);
             globalRoles.remove(globalRole);
@@ -220,7 +220,7 @@ public class FolderBasedAuthorizationStrategy extends AuthorizationStrategy {
         role.assignSids(sid);
 
         try {
-            Jenkins.getInstance().save();
+            Jenkins.get().save();
         } catch (IOException e) {
             LOGGER.log(Level.SEVERE, "Unable to save config file, not assigning the sids.", e);
             role.unassignSids(sid);
@@ -248,7 +248,7 @@ public class FolderBasedAuthorizationStrategy extends AuthorizationStrategy {
     public void addFolderRole(@Nonnull FolderRole folderRole) throws IOException {
         folderRoles.add(folderRole);
         try {
-            Jenkins.getInstance().save();
+            Jenkins.get().save();
         } catch (IOException e) {
             LOGGER.log(Level.SEVERE, "Unable to save configuration when adding folder role.", e);
             folderRoles.remove(folderRole);
@@ -276,7 +276,7 @@ public class FolderBasedAuthorizationStrategy extends AuthorizationStrategy {
 
         role.assignSids(sid);
         try {
-            Jenkins.getInstance().save();
+            Jenkins.get().save();
         } catch (IOException e) {
             LOGGER.log(Level.SEVERE, "Unable to save config file, not assigning the sids.", e);
             role.unassignSids(sid);
@@ -332,7 +332,7 @@ public class FolderBasedAuthorizationStrategy extends AuthorizationStrategy {
         globalRoles.remove(role);
 
         try {
-            Jenkins.getInstance().save();
+            Jenkins.get().save();
         } catch (IOException e) {
             LOGGER.log(Level.SEVERE, "Unable to save the config when deleting global role. " +
                     "The role was not deleted.", e);
@@ -359,7 +359,7 @@ public class FolderBasedAuthorizationStrategy extends AuthorizationStrategy {
         folderRoles.remove(role);
 
         try {
-            Jenkins.getInstance().save();
+            Jenkins.get().save();
         } catch (IOException e) {
             LOGGER.log(Level.SEVERE, "Unable to save the config when deleting folder role. " +
                     "The role was not deleted.", e);


### PR DESCRIPTION
* Now builds with Java 11
* Remove reference to Role Strategy from Release Drafter
* Use recommended configurations for `buildPlugin`
* Add SCM info to POM
* Replace deprecated `Jenkins.getInstance()` with `Jenkins.get()`

@jenkinsci/gsoc2019-role-strategy 