### PR TITLE
Asynchronously render Folder list

### DIFF
--- a/src/main/java/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink.java
+++ b/src/main/java/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.folderauth;
 
 import com.cloudbees.hudson.plugins.folder.AbstractFolder;
 import hudson.Extension;
+import hudson.model.AbstractItem;
 import hudson.model.Computer;
 import hudson.model.ManagementLink;
 import hudson.security.ACL;
@@ -15,12 +16,14 @@ import io.jenkins.plugins.folderauth.misc.PermissionWrapper;
 import io.jenkins.plugins.folderauth.roles.FolderRole;
 import io.jenkins.plugins.folderauth.roles.GlobalRole;
 import jenkins.model.Jenkins;
+import net.sf.json.JSONArray;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 import org.kohsuke.stapler.json.JsonBody;
+import org.kohsuke.stapler.verb.GET;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -31,6 +34,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 @Extension
 public class FolderAuthorizationStrategyManagementLink extends ManagementLink {
@@ -191,11 +195,12 @@ public class FolderAuthorizationStrategyManagementLink extends ManagementLink {
     /**
      * Get all {@link AbstractFolder}s in the system
      *
-     * @return folders in the system
+     * @return full names of all {@link AbstractFolder}s in the system
      */
+    @GET
     @Nonnull
     @Restricted(NoExternalUse.class)
-    public List<AbstractFolder> getAllFolders() {
+    public JSONArray doGetAllFolders() {
         Jenkins jenkins = Jenkins.get();
         jenkins.checkPermission(Jenkins.ADMINISTER);
         List<AbstractFolder> folders;
@@ -204,7 +209,7 @@ public class FolderAuthorizationStrategyManagementLink extends ManagementLink {
             folders = jenkins.getAllItems(AbstractFolder.class);
         }
 
-        return folders;
+        return JSONArray.fromObject(folders.stream().map(AbstractItem::getFullName).collect(Collectors.toList()));
     }
 
     /**

--- a/src/main/resources/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink/index.jelly
@@ -4,6 +4,7 @@
         <st:include it="${app}" page="sidepanel.jelly" optional="true"/>
         <l:main-panel>
             <script src="${rootURL}/plugin/folder-auth/js/globalrole.js"/>
+            <script src="${rootURL}/plugin/folder-auth/js/folderrole.js"/>
             <link rel="stylesheet" href="${rootURL}/plugin/folder-auth/css/folder-strategy.css" type="text/css"/>
             <div>
                 <h1>${%manageGlobalRoles}</h1>
@@ -129,12 +130,17 @@
                         </label>
                     </div>
                     <div class="form-row">
+                        <script>
+                            // asynchronously render folder names
+                            getFolders();
+                        </script>
                         <label class="form-label">
                             ${%applyOn}:
-                            <select name="folderNames" multiple="multiple" id="folder-select" class="form-control">
-                                <j:forEach items="${it.allFolders}" var="folder">
-                                    <option value="${folder.fullName}">${folder.fullName}</option>
-                                </j:forEach>
+                            <div id="loading-folders" class="loading">
+                                ${%loadingFolders}
+                            </div>
+                            <select name="folderNames" multiple="multiple" id="folder-select" class="form-control"
+                                    style="display: none;">
                             </select>
                         </label>
                     </div>
@@ -147,7 +153,10 @@
                         </select>
                     </label>
                     <div class="form-row">
-                        <button type="button" class="submit-button" onclick="addFolderRole();">${%addRole}</button>
+                        <button id="add-folder-role-button" type="button" class="submit-button" onclick="addFolderRole();"
+                                disabled="disabled">
+                            ${%addRole}
+                        </button>
                     </div>
                 </div>
             </div>

--- a/src/main/resources/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink/index.properties
+++ b/src/main/resources/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink/index.properties
@@ -16,3 +16,4 @@ currentFolderRoles=Current Folder Roles
 folders=Folders
 addFolderRole=Add a Folder Role
 applyOnFolders=Apply on
+loadingFolders=Loading Folders...

--- a/src/main/webapp/css/folder-strategy.css
+++ b/src/main/webapp/css/folder-strategy.css
@@ -25,6 +25,12 @@ div.role-container {
     overflow-y: scroll;
 }
 
+.loading {
+    padding-top: 7px;
+    font-size: 12px;
+    font-weight: lighter;
+}
+
 div.role {
     display: flex;
     flex-direction: column;

--- a/src/main/webapp/js/folderrole.js
+++ b/src/main/webapp/js/folderrole.js
@@ -23,6 +23,13 @@ const getFolders = () => {
  */
 const renderFoldersAsOptions = (folders) => {
     const select = document.getElementById('folder-select');
+    const loadingLabel = document.getElementById('loading-folders');
+
+    if (!(Array.isArray(folders) && folders.length)) {
+        loadingLabel.innerText = 'Please create a folder before adding a folder role.';
+        return;
+    }
+
     folders.forEach(folder => {
         const option = document.createElement('option');
         option.value = folder;
@@ -34,7 +41,6 @@ const renderFoldersAsOptions = (folders) => {
     select.style.display = 'block';
 
     // remove the 'Loading folders' label
-    const loadingLabel = document.getElementById('loading-folders');
     loadingLabel.parentElement.removeChild(loadingLabel);
 
     // enable submitting the form

--- a/src/main/webapp/js/folderrole.js
+++ b/src/main/webapp/js/folderrole.js
@@ -1,0 +1,42 @@
+'use strict';
+
+/**
+ * Sends a GET request and renders the result on the web page.
+ */
+const getFolders = () => {
+    const xhr = new XMLHttpRequest();
+    xhr.open('GET', `${rootURL}/folder-auth/getAllFolders`, true);
+    xhr.send(null);
+
+    xhr.onload = () => {
+        renderFoldersAsOptions(JSON.parse(xhr.responseText));
+    };
+
+    xhr.onerror = () => {
+        alert(`Unable to get the list of folders: ${xhr.responseText}`);
+    };
+};
+
+/**
+ * Renders all folders on the web UI.
+ * @param folders list of folder names
+ */
+const renderFoldersAsOptions = (folders) => {
+    const select = document.getElementById('folder-select');
+    folders.forEach(folder => {
+        const option = document.createElement('option');
+        option.value = folder;
+        option.innerHTML = folder;
+        select.appendChild(option);
+    });
+
+    // make the <select> element visible
+    select.style.display = 'block';
+
+    // remove the 'Loading folders' label
+    const loadingLabel = document.getElementById('loading-folders');
+    loadingLabel.parentElement.removeChild(loadingLabel);
+
+    // enable submitting the form
+    document.getElementById('add-folder-role-button').removeAttribute('disabled');
+};


### PR DESCRIPTION
Based on Oleg's comments in the Gitter chat:
> Folder selector provides a list of folders. Such list may take a while to load on big instances, and it would be really big. The biggest instance I see in my bugfix database has around 6k folders.

This the first step in rendering folders names on the client side.