### PR TITLE
Add benchmarks for `GlobalRole`s and `FolderRole`s

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,3 @@
 // Builds a module using https://github.com/jenkins-infra/pipeline-library
 buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+runBenchmarks('jmh-report.json')

--- a/src/test/java/io/jenkins/plugins/folderauth/jmh/BenchmarkRunner.java
+++ b/src/test/java/io/jenkins/plugins/folderauth/jmh/BenchmarkRunner.java
@@ -1,0 +1,31 @@
+package io.jenkins.plugins.folderauth.jmh;
+
+import jenkins.benchmark.jmh.BenchmarkFinder;
+import org.junit.Test;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+public class BenchmarkRunner {
+    @Test
+    public void runBenchmarks() throws IOException, RunnerException {
+        ChainedOptionsBuilder options = new OptionsBuilder()
+                                            .forks(2)
+                                            .mode(Mode.AverageTime)
+                                            .shouldDoGC(true)
+                                            .shouldFailOnError(true)
+                                            .result("jmh-report.json")
+                                            .resultFormat(ResultFormatType.JSON)
+                                            .timeUnit(TimeUnit.MICROSECONDS)
+                                            .threads(2);
+
+        new BenchmarkFinder(BenchmarkRunner.class).findBenchmarks(options);
+        new Runner(options.build()).run();
+    }
+}

--- a/src/test/java/io/jenkins/plugins/folderauth/jmh/benchmarks/FolderRoleBenchmark.java
+++ b/src/test/java/io/jenkins/plugins/folderauth/jmh/benchmarks/FolderRoleBenchmark.java
@@ -1,0 +1,110 @@
+package io.jenkins.plugins.folderauth.jmh.benchmarks;
+
+import com.cloudbees.hudson.plugins.folder.Folder;
+import com.google.common.collect.ImmutableSet;
+import hudson.model.FreeStyleProject;
+import hudson.model.Item;
+import hudson.model.User;
+import io.jenkins.plugins.folderauth.FolderBasedAuthorizationStrategy;
+import io.jenkins.plugins.folderauth.roles.FolderRole;
+import io.jenkins.plugins.folderauth.roles.GlobalRole;
+import jenkins.benchmark.jmh.JmhBenchmark;
+import jenkins.benchmark.jmh.JmhBenchmarkState;
+import jenkins.model.Jenkins;
+import org.acegisecurity.context.SecurityContext;
+import org.acegisecurity.context.SecurityContextHolder;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Random;
+import java.util.Set;
+
+import static io.jenkins.plugins.folderauth.misc.PermissionWrapper.wrapPermissions;
+
+/**
+ * Benchmarks for {@link FolderRole}s based on the configuration of
+ * https://github.com/jenkinsci/role-strategy-plugin/blob/master/src/test/java/jmh/benchmarks/FolderAccessBenchmark.java
+ */
+@JmhBenchmark
+public class FolderRoleBenchmark {
+    public static class MyState extends JmhBenchmarkState {
+
+        @Override
+        public void setup() throws Exception {
+            Jenkins jenkins = getJenkins();
+            jenkins.setSecurityRealm(new JenkinsRule().createDummySecurityRealm());
+
+            Set<GlobalRole> globalRoles = ImmutableSet.of((
+                    new GlobalRole("ADMIN", wrapPermissions(Jenkins.ADMINISTER), Collections.singleton("admin"))),
+                new GlobalRole("read", wrapPermissions(Jenkins.READ), Collections.singleton("authenticated"))
+            );
+
+            Set<FolderRole> folderRoles = new HashSet<>();
+
+            Random random = new Random(100L);
+
+            // create the folders
+            for (int i = 0; i < 10; i++) {
+                String topFolderName = "TopFolder" + i;
+                Folder folder = jenkins.createProject(Folder.class, topFolderName);
+
+                Set<String> users = new HashSet<>();
+                for (int k = 0; k < random.nextInt(5); k++) {
+                    users.add("user" + random.nextInt(100));
+                }
+
+                FolderRole userRole = new FolderRole(topFolderName, wrapPermissions(Item.READ, Item.DISCOVER),
+                    Collections.singleton(topFolderName), users);
+
+                folderRoles.add(userRole);
+
+                for (int j = 0; j < 5; j++) {
+                    Folder bottom = folder.createProject(Folder.class, "BottomFolder" + j);
+
+                    Set<String> maintainers = new HashSet<>(2);
+                    maintainers.add("user" + random.nextInt(100));
+                    maintainers.add("user" + random.nextInt(100));
+
+                    FolderRole maintainerRole = new FolderRole(bottom.getFullName(),
+                        wrapPermissions(Item.READ, Item.DISCOVER, Item.CREATE),
+                        Collections.singleton(topFolderName), maintainers);
+
+                    Set<String> admin = Collections.singleton("user" + random.nextInt(100));
+
+                    FolderRole folderAdminRole = new FolderRole(bottom.getFullName(), wrapPermissions(Item.READ, Item.DISCOVER,
+                        Item.CONFIGURE, Item.CREATE), Collections.singleton(topFolderName), admin);
+                    folderRoles.add(maintainerRole);
+                    folderRoles.add(folderAdminRole);
+
+                    for (int k = 0; k < 5; k++) {
+                        bottom.createProject(FreeStyleProject.class, "Project" + k);
+                    }
+                }
+            }
+
+            jenkins.setAuthorizationStrategy(new FolderBasedAuthorizationStrategy(globalRoles, folderRoles));
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class ThreadState {
+        @Setup(Level.Iteration)
+        public void setup() {
+            SecurityContext securityContext = SecurityContextHolder.getContext();
+            securityContext.setAuthentication(Objects.requireNonNull(User.getById("user33", true)).impersonate());
+        }
+    }
+
+    @Benchmark
+    public void renderViewSimulation(MyState state, ThreadState threadState, Blackhole blackhole) {
+        blackhole.consume(state.getJenkins().getAllItems());
+    }
+}

--- a/src/test/java/io/jenkins/plugins/folderauth/jmh/benchmarks/GlobalRoleBenchmark.java
+++ b/src/test/java/io/jenkins/plugins/folderauth/jmh/benchmarks/GlobalRoleBenchmark.java
@@ -1,0 +1,118 @@
+package io.jenkins.plugins.folderauth.jmh.benchmarks;
+
+import com.google.common.collect.ImmutableSet;
+import hudson.model.Item;
+import hudson.model.User;
+import io.jenkins.plugins.folderauth.FolderBasedAuthorizationStrategy;
+import io.jenkins.plugins.folderauth.acls.GlobalAclImpl;
+import io.jenkins.plugins.folderauth.roles.GlobalRole;
+import jenkins.benchmark.jmh.JmhBenchmark;
+import jenkins.benchmark.jmh.JmhBenchmarkState;
+import org.acegisecurity.context.SecurityContext;
+import org.acegisecurity.context.SecurityContextHolder;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import static io.jenkins.plugins.folderauth.misc.PermissionWrapper.wrapPermissions;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * This benchmark is created to test the performance of GlobalRoles. This test is inspired from
+ * https://github.com/jenkinsci/role-strategy-plugin/blob/master/src/test/java/jmh/benchmarks/RoleMapBenchmark.java .
+ * <p>
+ * This tests the scalability of the performance of {@link GlobalAclImpl} with increased number of roles.
+ * Do note that "user3" does not have the {@link Item#CREATE} permission.
+ */
+@JmhBenchmark
+@SuppressWarnings("unused")
+public class GlobalRoleBenchmark {
+    public static class GlobalRoles050 extends GlobalRoleBenchmarkState {
+        @Override
+        int getRoleCount() {
+            return 50;
+        }
+    }
+
+    public static class GlobalRoles100 extends GlobalRoleBenchmarkState {
+        @Override
+        int getRoleCount() {
+            return 100;
+        }
+    }
+
+    public static class GlobalRoles200 extends GlobalRoleBenchmarkState {
+        @Override
+        int getRoleCount() {
+            return 200;
+        }
+    }
+
+    public static class GlobalRoles500 extends GlobalRoleBenchmarkState {
+        @Override
+        int getRoleCount() {
+            return 500;
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class ThreadState {
+        @Setup(Level.Iteration)
+        public void setup() {
+            SecurityContext holder = SecurityContextHolder.getContext();
+            holder.setAuthentication(Objects.requireNonNull(User.getById("user3", true)).impersonate());
+        }
+    }
+
+    @Benchmark
+    public void benchmark050(GlobalRoles050 state, ThreadState threadState, Blackhole blackhole) {
+        assertFalse(state.acl.hasPermission(Item.CREATE));
+    }
+
+    @Benchmark
+    public void benchmark100(GlobalRoles100 state, ThreadState threadState, Blackhole blackhole) {
+        blackhole.consume(state.acl.hasPermission(Item.CREATE));
+    }
+
+    @Benchmark
+    public void benchmark200(GlobalRoles200 state, ThreadState threadState, Blackhole blackhole) {
+        blackhole.consume(state.acl.hasPermission(Item.CREATE));
+    }
+
+    @Benchmark
+    public void benchmark500(GlobalRoles500 state, ThreadState threadState, Blackhole blackhole) {
+        blackhole.consume(state.acl.hasPermission(Item.CREATE));
+    }
+}
+
+abstract class GlobalRoleBenchmarkState extends JmhBenchmarkState {
+
+    GlobalAclImpl acl;
+
+    @Override
+    public void setup() {
+        getJenkins().setSecurityRealm(new JenkinsRule().createDummySecurityRealm());
+        Set<GlobalRole> globalRoles = new HashSet<>();
+        for (int i = 0; i < getRoleCount(); i++) {
+            globalRoles.add(new GlobalRole("role" + i, wrapPermissions(Item.DISCOVER, Item.CONFIGURE),
+                ImmutableSet.of("user" + i)));
+        }
+
+        FolderBasedAuthorizationStrategy strategy = new FolderBasedAuthorizationStrategy(
+            globalRoles, Collections.emptySet());
+        acl = strategy.getRootACL();
+        assertFalse(acl.hasPermission(Objects.requireNonNull(User.getById("user3", true)).impersonate(),
+            Item.CREATE));
+    }
+
+    abstract int getRoleCount();
+}


### PR DESCRIPTION
Adds a benchmark to compare the performance of `hasPermission()` checks for global roles with those from the Role Strategy Plugin.

The benchmark emulates https://github.com/jenkinsci/role-strategy-plugin/blob/master/src/test/java/jmh/benchmarks/RoleMapBenchmark.java 