### PR TITLE
Listen to configuration changes on `Folder`s and update folder roles

### DIFF
--- a/src/main/java/io/jenkins/plugins/folderauth/FolderBasedAuthorizationStrategy.java
+++ b/src/main/java/io/jenkins/plugins/folderauth/FolderBasedAuthorizationStrategy.java
@@ -533,7 +533,7 @@ public class FolderBasedAuthorizationStrategy extends AuthorizationStrategy {
     @Restricted(NoExternalUse.class)
     public void onFolderRenamed(String oldFullName, String newFullName) {
         folderRoles.parallelStream().forEach(role -> {
-            if (role.getFolderNames().contains(newFullName)) {
+            if (role.getFolderNames().contains(oldFullName)) {
                 role.removeFolder(oldFullName);
                 role.addFolder(newFullName);
             }

--- a/src/main/java/io/jenkins/plugins/folderauth/listeners/FolderListener.java
+++ b/src/main/java/io/jenkins/plugins/folderauth/listeners/FolderListener.java
@@ -1,0 +1,39 @@
+package io.jenkins.plugins.folderauth.listeners;
+
+import com.cloudbees.hudson.plugins.folder.AbstractFolder;
+import hudson.Extension;
+import hudson.model.Item;
+import hudson.model.listeners.ItemListener;
+import hudson.security.AuthorizationStrategy;
+import io.jenkins.plugins.folderauth.FolderBasedAuthorizationStrategy;
+import jenkins.model.Jenkins;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * Listens for changes to {@link AbstractFolder}s in Jenkins and makes sure that the configuration of
+ * {@link FolderBasedAuthorizationStrategy} remains the same.
+ * <p>
+ * Does not do anything if {@link Jenkins#getAuthorizationStrategy} is not {@link FolderBasedAuthorizationStrategy}.
+ */
+@Extension
+@Restricted(NoExternalUse.class)
+public class FolderListener extends ItemListener {
+    @Override
+    public void onDeleted(Item item) {
+        AuthorizationStrategy a = Jenkins.get().getAuthorizationStrategy();
+        if (item instanceof AbstractFolder && a instanceof FolderBasedAuthorizationStrategy) {
+            FolderBasedAuthorizationStrategy strategy = (FolderBasedAuthorizationStrategy) a;
+            strategy.onFolderDeleted(item.getFullName());
+        }
+    }
+
+    @Override
+    public void onLocationChanged(Item item, String oldFullName, String newFullName) {
+        AuthorizationStrategy a = Jenkins.get().getAuthorizationStrategy();
+        if (item instanceof AbstractFolder && a instanceof FolderBasedAuthorizationStrategy) {
+            FolderBasedAuthorizationStrategy strategy = (FolderBasedAuthorizationStrategy) a;
+            strategy.onFolderRenamed(oldFullName, newFullName);
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/folderauth/roles/FolderRole.java
+++ b/src/main/java/io/jenkins/plugins/folderauth/roles/FolderRole.java
@@ -1,6 +1,8 @@
 package io.jenkins.plugins.folderauth.roles;
 
 import io.jenkins.plugins.folderauth.misc.PermissionWrapper;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import javax.annotation.Nonnull;
@@ -16,7 +18,6 @@ public class FolderRole extends AbstractRole implements Comparable<FolderRole> {
 
     @DataBoundConstructor
     @ParametersAreNonnullByDefault
-    @SuppressWarnings("WeakerAccess")
     public FolderRole(String name, Set<PermissionWrapper> permissions, Set<String> folders, Set<String> sids) {
         super(name, permissions);
         this.sids.addAll(sids);
@@ -56,6 +57,28 @@ public class FolderRole extends AbstractRole implements Comparable<FolderRole> {
     @Nonnull
     public Set<String> getFolderNames() {
         return Collections.unmodifiableSet(folders);
+    }
+
+    /**
+     * The role no longer remains valid on the given {@link com.cloudbees.hudson.plugins.folder.AbstractFolder}
+     * identified by its full name.
+     * <p>
+     * Does not do anything if the role was not valid on the folder before the call to this function was made.
+     *
+     * @param fullName the full name of the folder that was deleted.
+     */
+    @Restricted(NoExternalUse.class)
+    public void removeFolder(String fullName) {
+        folders.remove(fullName);
+    }
+
+    /**
+     * Makes the role applicable on the given {@link com.cloudbees.hudson.plugins.folder.AbstractFolder} identified
+     * by its full name.
+     */
+    @Restricted(NoExternalUse.class)
+    public void addFolder(String fullName) {
+        folders.add(fullName);
     }
 
     /**


### PR DESCRIPTION
This pull request addresses concerns on the applicability on `Item.CONFIGURE` on parent folders as a part of folder roles.

Renames of folders now also update the folder roles with their new full names. Deletion of a folder causes it's name to be deleted from the respective folder roles.

See the [discussion](https://gitter.im/jenkinsci/role-strategy-plugin?at=5d394b0aef4271596f55c64b) on the Gitter chat.