### PR TITLE
[JENKINS-58723] Make the AuthorizationStrategy immutable

### DIFF
--- a/src/main/java/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyAPI.java
+++ b/src/main/java/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyAPI.java
@@ -5,6 +5,7 @@ import io.jenkins.plugins.folderauth.roles.AgentRole;
 import io.jenkins.plugins.folderauth.roles.FolderRole;
 import io.jenkins.plugins.folderauth.roles.GlobalRole;
 import jenkins.model.Jenkins;
+import org.apache.commons.lang.StringUtils;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.HashSet;
@@ -115,8 +116,13 @@ public class FolderAuthorizationStrategyAPI {
      * @param sid      this sid will be assigned to the global role with the name equal to {@code roleName}.
      * @param roleName the name of the global role
      * @throws IllegalArgumentException when no global role with name equal to {@code roleName} exists
+     * @throws IllegalArgumentException when the {@code sid} is empty
      */
     public static void assignSidToGlobalRole(String sid, String roleName) {
+        if (StringUtils.isBlank(sid)) {
+            throw new IllegalArgumentException("Sid should not be blank.");
+        }
+
         run(strategy -> {
             Set<GlobalRole> globalRoles = new HashSet<>(strategy.getGlobalRoles());
             GlobalRole role = globalRoles.stream().filter(r -> r.getName().equals(roleName)).findAny().orElseThrow(
@@ -135,8 +141,13 @@ public class FolderAuthorizationStrategyAPI {
      * @param sid      this sid will be assigned to the {@link AgentRole} with the name equal to {@code roleName}.
      * @param roleName the name of the agent role
      * @throws IllegalArgumentException when no agent role with name equal to {@code roleName} exists
+     * @throws IllegalArgumentException when the {@code sid} is empty
      */
     public static void assignSidToAgentRole(String sid, String roleName) {
+        if (StringUtils.isBlank(sid)) {
+            throw new IllegalArgumentException("Sid should not be blank.");
+        }
+
         run(strategy -> {
             Set<AgentRole> agentRoles = new HashSet<>(strategy.getAgentRoles());
             AgentRole role = agentRoles.stream().filter(r -> r.getName().equals(roleName)).findAny().orElseThrow(
@@ -155,8 +166,13 @@ public class FolderAuthorizationStrategyAPI {
      * @param sid      this sid will be assigned to the {@link FolderRole} with the name equal to {@code roleName}.
      * @param roleName the name of the folder role
      * @throws IllegalArgumentException when no folder role with name equal to {@code roleName} exists
+     * @throws IllegalArgumentException when the {@code sid} is empty
      */
     public static void assignSidToFolderRole(String sid, String roleName) {
+        if (StringUtils.isBlank(sid)) {
+            throw new IllegalArgumentException("Sid should not be blank.");
+        }
+
         run(strategy -> {
             Set<FolderRole> folderRoles = new HashSet<>(strategy.getFolderRoles());
             FolderRole role = folderRoles.stream().filter(r -> r.getName().equals(roleName)).findAny().orElseThrow(

--- a/src/main/java/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyAPI.java
+++ b/src/main/java/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyAPI.java
@@ -8,6 +8,7 @@ import jenkins.model.Jenkins;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -55,10 +56,16 @@ public class FolderAuthorizationStrategyAPI {
      * Adds a {@link GlobalRole} to the {@link FolderBasedAuthorizationStrategy}.
      *
      * @param role the role to be added.
+     * @throws IllegalArgumentException when a role with the given name already exists.
      */
     public static void addGlobalRole(GlobalRole role) {
         run(strategy -> {
             Set<GlobalRole> globalRoles = new HashSet<>(strategy.getGlobalRoles());
+            String name = role.getName();
+            Optional<GlobalRole> existing = globalRoles.stream().filter(r -> r.getName().equals(name)).findAny();
+            if (existing.isPresent()) {
+                throw new IllegalArgumentException("A global role with the name \"" + name + "\" already exists.");
+            }
             globalRoles.add(role);
             return new FolderBasedAuthorizationStrategy(globalRoles, strategy.getFolderRoles(), strategy.getAgentRoles());
         });
@@ -68,10 +75,16 @@ public class FolderAuthorizationStrategyAPI {
      * Adds a {@link FolderRole} to the {@link FolderBasedAuthorizationStrategy}.
      *
      * @param role the role to be added.
+     * @throws IllegalArgumentException when a role with the given name already exists.
      */
     public static void addFolderRole(FolderRole role) {
         run(strategy -> {
             Set<FolderRole> folderRoles = new HashSet<>(strategy.getFolderRoles());
+            String name = role.getName();
+            Optional<FolderRole> existing = folderRoles.stream().filter(r -> r.getName().equals(name)).findAny();
+            if (existing.isPresent()) {
+                throw new IllegalArgumentException("A folder role with the name \"" + name + "\" already exists.");
+            }
             folderRoles.add(role);
             return new FolderBasedAuthorizationStrategy(strategy.getGlobalRoles(), folderRoles, strategy.getAgentRoles());
         });
@@ -81,10 +94,16 @@ public class FolderAuthorizationStrategyAPI {
      * Adds an {@link AgentRole} to the {@link FolderBasedAuthorizationStrategy}.
      *
      * @param role the role to be added.
+     * @throws IllegalArgumentException when a role with the given name already exists.
      */
     public static void addAgentRole(AgentRole role) {
         run(strategy -> {
             Set<AgentRole> agentRoles = new HashSet<>(strategy.getAgentRoles());
+            String name = role.getName();
+            Optional<AgentRole> existing = agentRoles.stream().filter(r -> r.getName().equals(name)).findAny();
+            if (existing.isPresent()) {
+                throw new IllegalArgumentException("An agent role with the name \"" + name + "\" already exists.");
+            }
             agentRoles.add(role);
             return new FolderBasedAuthorizationStrategy(strategy.getGlobalRoles(), strategy.getFolderRoles(), agentRoles);
         });

--- a/src/main/java/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink.java
+++ b/src/main/java/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink.java
@@ -54,7 +54,7 @@ public class FolderAuthorizationStrategyManagementLink extends ManagementLink {
     @Override
     public String getIconFileName() {
         return Jenkins.get().getAuthorizationStrategy() instanceof FolderBasedAuthorizationStrategy ?
-                "lock.png" : null;
+                   "lock.png" : null;
     }
 
     @CheckForNull
@@ -107,21 +107,14 @@ public class FolderAuthorizationStrategyManagementLink extends ManagementLink {
      * Adds a {@link GlobalRole} to {@link FolderBasedAuthorizationStrategy}.
      *
      * @param request the request to create the {@link GlobalRole}
-     * @throws IOException           when unable to add Global role
      * @throws IllegalStateException when {@link Jenkins#getAuthorizationStrategy()} is
      *                               not {@link FolderBasedAuthorizationStrategy}
      */
     @RequirePOST
     @Restricted(NoExternalUse.class)
-    public void doAddGlobalRole(@JsonBody GlobalRoleCreationRequest request) throws IOException {
-        Jenkins jenkins = Jenkins.get();
-        jenkins.checkPermission(Jenkins.ADMINISTER);
-        AuthorizationStrategy strategy = jenkins.getAuthorizationStrategy();
-        if (strategy instanceof FolderBasedAuthorizationStrategy) {
-            ((FolderBasedAuthorizationStrategy) strategy).addGlobalRole(request.getGlobalRole());
-        } else {
-            throw new IllegalStateException(Messages.FolderBasedAuthorizationStrategy_NotCurrentStrategy());
-        }
+    public void doAddGlobalRole(@JsonBody GlobalRoleCreationRequest request) {
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        FolderAuthorizationStrategyAPI.addGlobalRole(request.getGlobalRole());
     }
 
     /**
@@ -131,62 +124,45 @@ public class FolderAuthorizationStrategyManagementLink extends ManagementLink {
      *
      * @param roleName the name of the global to which {@code sid} will be assigned to.
      * @param sid      the sid of the user/group to be assigned.
-     * @throws IOException                      when unable to assign the Sid to the role
-     * @throws IllegalStateException            when {@link Jenkins#getAuthorizationStrategy()} is
-     *                                          not {@link FolderBasedAuthorizationStrategy}
-     * @throws java.util.NoSuchElementException when no role with name equal to {@code roleName} exists.
+     * @throws IllegalStateException    when {@link Jenkins#getAuthorizationStrategy()} is
+     *                                  not {@link FolderBasedAuthorizationStrategy}
+     * @throws IllegalArgumentException when no role with name equal to {@code roleName} exists.
      */
     @RequirePOST
     @Restricted(NoExternalUse.class)
     public void doAssignSidToGlobalRole(@QueryParameter(required = true) String roleName,
-                                        @QueryParameter(required = true) String sid) throws IOException {
-        Jenkins jenkins = Jenkins.get();
-        jenkins.checkPermission(Jenkins.ADMINISTER);
-        AuthorizationStrategy strategy = jenkins.getAuthorizationStrategy();
-        if (strategy instanceof FolderBasedAuthorizationStrategy) {
-            ((FolderBasedAuthorizationStrategy) strategy).assignSidToGlobalRole(roleName, sid);
-            redirect();
-        } else {
-            throw new IllegalStateException(Messages.FolderBasedAuthorizationStrategy_NotCurrentStrategy());
-        }
+                                        @QueryParameter(required = true) String sid) {
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        FolderAuthorizationStrategyAPI.assignSidToGlobalRole(sid, roleName);
+        redirect();
     }
 
     /**
      * Adds a {@link FolderRole} to {@link FolderBasedAuthorizationStrategy}.
      *
      * @param request the request to create the role
-     * @throws IOException           when unable to add the role
      * @throws IllegalStateException when {@link Jenkins#getAuthorizationStrategy()} is
      *                               not {@link FolderBasedAuthorizationStrategy}
      */
     @RequirePOST
     @Restricted(NoExternalUse.class)
-    public void doAddFolderRole(@JsonBody FolderRoleCreationRequest request) throws IOException {
-        Jenkins jenkins = Jenkins.get();
-        jenkins.checkPermission(Jenkins.ADMINISTER);
-        AuthorizationStrategy strategy = jenkins.getAuthorizationStrategy();
-        if (strategy instanceof FolderBasedAuthorizationStrategy) {
-            ((FolderBasedAuthorizationStrategy) strategy).addFolderRole(request.getFolderRole());
-        }
+    public void doAddFolderRole(@JsonBody FolderRoleCreationRequest request) {
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        FolderAuthorizationStrategyAPI.addFolderRole(request.getFolderRole());
     }
 
     /**
      * Adds an {@link AgentRole} to {@link FolderBasedAuthorizationStrategy}.
      *
      * @param request the request to create the role
-     * @throws IOException           when unable to add the role
      * @throws IllegalStateException when {@link Jenkins#getAuthorizationStrategy()} is
      *                               not {@link FolderBasedAuthorizationStrategy}
      */
     @RequirePOST
     @Restricted(NoExternalUse.class)
-    public void doAddAgentRole(@JsonBody AgentRoleCreationRequest request) throws IOException {
-        Jenkins jenkins = Jenkins.get();
-        jenkins.checkPermission(Jenkins.ADMINISTER);
-        AuthorizationStrategy strategy = jenkins.getAuthorizationStrategy();
-        if (strategy instanceof FolderBasedAuthorizationStrategy) {
-            ((FolderBasedAuthorizationStrategy) strategy).addAgentRole(request.getAgentRole());
-        }
+    public void doAddAgentRole(@JsonBody AgentRoleCreationRequest request) {
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        FolderAuthorizationStrategyAPI.addAgentRole(request.getAgentRole());
     }
 
     /**
@@ -195,7 +171,6 @@ public class FolderAuthorizationStrategyManagementLink extends ManagementLink {
      *
      * @param roleName the name of the global to which {@code sid} will be assigned to.
      * @param sid      the sid of the user/group to be assigned.
-     * @throws IOException                      when unable to assign the Sid to the role
      * @throws IllegalStateException            when {@link Jenkins#getAuthorizationStrategy()} is
      *                                          not {@link FolderBasedAuthorizationStrategy}
      * @throws java.util.NoSuchElementException when no role with name equal to {@code roleName} exists.
@@ -203,16 +178,10 @@ public class FolderAuthorizationStrategyManagementLink extends ManagementLink {
     @RequirePOST
     @Restricted(NoExternalUse.class)
     public void doAssignSidToFolderRole(@QueryParameter(required = true) String roleName,
-                                        @QueryParameter(required = true) String sid) throws IOException {
-        Jenkins jenkins = Jenkins.get();
-        jenkins.checkPermission(Jenkins.ADMINISTER);
-        AuthorizationStrategy strategy = jenkins.getAuthorizationStrategy();
-        if (strategy instanceof FolderBasedAuthorizationStrategy) {
-            ((FolderBasedAuthorizationStrategy) strategy).assignSidToFolderRole(roleName, sid);
-            redirect();
-        } else {
-            throw new IllegalStateException(Messages.FolderBasedAuthorizationStrategy_NotCurrentStrategy());
-        }
+                                        @QueryParameter(required = true) String sid) {
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        FolderAuthorizationStrategyAPI.assignSidToFolderRole(sid, roleName);
+        redirect();
     }
 
     /**
@@ -221,24 +190,17 @@ public class FolderAuthorizationStrategyManagementLink extends ManagementLink {
      *
      * @param roleName the name of the global to which {@code sid} will be assigned to.
      * @param sid      the sid of the user/group to be assigned.
-     * @throws IOException                      when unable to assign the Sid to the role
-     * @throws IllegalStateException            when {@link Jenkins#getAuthorizationStrategy()} is
-     *                                          not {@link FolderBasedAuthorizationStrategy}
-     * @throws java.util.NoSuchElementException when no role with name equal to {@code roleName} exists.
+     * @throws IllegalStateException    when {@link Jenkins#getAuthorizationStrategy()} is
+     *                                  not {@link FolderBasedAuthorizationStrategy}
+     * @throws IllegalArgumentException when no role with name equal to {@code roleName} exists.
      */
     @RequirePOST
     @Restricted(NoExternalUse.class)
     public void doAssignSidToAgentRole(@QueryParameter(required = true) String roleName,
-                                        @QueryParameter(required = true) String sid) throws IOException {
-        Jenkins jenkins = Jenkins.get();
-        jenkins.checkPermission(Jenkins.ADMINISTER);
-        AuthorizationStrategy strategy = jenkins.getAuthorizationStrategy();
-        if (strategy instanceof FolderBasedAuthorizationStrategy) {
-            ((FolderBasedAuthorizationStrategy) strategy).assignSidToAgentRole(roleName, sid);
-            redirect();
-        } else {
-            throw new IllegalStateException(Messages.FolderBasedAuthorizationStrategy_NotCurrentStrategy());
-        }
+                                       @QueryParameter(required = true) String sid) {
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        FolderAuthorizationStrategyAPI.assignSidToAgentRole(sid, roleName);
+        redirect();
     }
 
     /**
@@ -339,73 +301,49 @@ public class FolderAuthorizationStrategyManagementLink extends ManagementLink {
      * Deletes a global role.
      *
      * @param roleName the name of the role to be deleted
-     * @throws IOException                      when unable to delete the role
-     * @throws IllegalStateException            when {@link Jenkins#getAuthorizationStrategy()} is
-     *                                          not {@link FolderBasedAuthorizationStrategy}
-     * @throws IllegalArgumentException         when trying to delete the admin role
-     * @throws java.util.NoSuchElementException when no role with name equal to {@code roleName} exists.
+     * @throws IllegalStateException    when {@link Jenkins#getAuthorizationStrategy()} is
+     *                                  not {@link FolderBasedAuthorizationStrategy}
+     * @throws IllegalArgumentException when trying to delete the admin role
+     * @throws IllegalArgumentException when no role with name equal to {@code roleName} exists.
      */
     @RequirePOST
     @Restricted(NoExternalUse.class)
-    public void doDeleteGlobalRole(@QueryParameter(required = true) String roleName)
-            throws IOException {
-        Jenkins jenkins = Jenkins.get();
-        jenkins.checkPermission(Jenkins.ADMINISTER);
-        AuthorizationStrategy strategy = jenkins.getAuthorizationStrategy();
-        if (strategy instanceof FolderBasedAuthorizationStrategy) {
-            ((FolderBasedAuthorizationStrategy) strategy).deleteGlobalRole(roleName);
-            redirect();
-        } else {
-            throw new IllegalStateException(Messages.FolderBasedAuthorizationStrategy_NotCurrentStrategy());
-        }
+    public void doDeleteGlobalRole(@QueryParameter(required = true) String roleName) {
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        FolderAuthorizationStrategyAPI.deleteGlobalRole(roleName);
+        redirect();
     }
 
     /**
      * Deletes a folder role.
      *
      * @param roleName the name of the role to be deleted
-     * @throws IOException                      when unable to delete the role
-     * @throws IllegalStateException            when {@link Jenkins#getAuthorizationStrategy()} is
-     *                                          not {@link FolderBasedAuthorizationStrategy}
-     * @throws java.util.NoSuchElementException when no role with name equal to {@code roleName} exists.
+     * @throws IllegalStateException    when {@link Jenkins#getAuthorizationStrategy()} is
+     *                                  not {@link FolderBasedAuthorizationStrategy}
+     * @throws IllegalArgumentException when no role with name equal to {@code roleName} exists.
      */
     @RequirePOST
     @Restricted(NoExternalUse.class)
-    public void doDeleteFolderRole(@QueryParameter(required = true) String roleName)
-            throws IOException {
-        Jenkins jenkins = Jenkins.get();
-        jenkins.checkPermission(Jenkins.ADMINISTER);
-        AuthorizationStrategy strategy = jenkins.getAuthorizationStrategy();
-        if (strategy instanceof FolderBasedAuthorizationStrategy) {
-            ((FolderBasedAuthorizationStrategy) strategy).deleteFolderRole(roleName);
-            redirect();
-        } else {
-            throw new IllegalStateException(Messages.FolderBasedAuthorizationStrategy_NotCurrentStrategy());
-        }
+    public void doDeleteFolderRole(@QueryParameter(required = true) String roleName) {
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        FolderAuthorizationStrategyAPI.deleteFolderRole(roleName);
+        redirect();
     }
 
     /**
      * Deletes an {@link AgentRole} from the {@link FolderBasedAuthorizationStrategy}.
      *
      * @param roleName the name of the role to be deleted
-     * @throws IOException                      when unable to delete the role
      * @throws IllegalStateException            when {@link Jenkins#getAuthorizationStrategy()} is
      *                                          not {@link FolderBasedAuthorizationStrategy}
      * @throws java.util.NoSuchElementException when no role with name equal to {@code roleName} exists.
      */
     @RequirePOST
     @Restricted(NoExternalUse.class)
-    public void doDeleteAgentRole(@QueryParameter(required = true) String roleName)
-            throws IOException {
-        Jenkins jenkins = Jenkins.get();
-        jenkins.checkPermission(Jenkins.ADMINISTER);
-        AuthorizationStrategy strategy = jenkins.getAuthorizationStrategy();
-        if (strategy instanceof FolderBasedAuthorizationStrategy) {
-            ((FolderBasedAuthorizationStrategy) strategy).deleteAgentRole(roleName);
-            redirect();
-        } else {
-            throw new IllegalStateException(Messages.FolderBasedAuthorizationStrategy_NotCurrentStrategy());
-        }
+    public void doDeleteAgentRole(@QueryParameter(required = true) String roleName) {
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        FolderAuthorizationStrategyAPI.deleteAgentRole(roleName);
+        redirect();
     }
 
     @Nonnull

--- a/src/main/java/io/jenkins/plugins/folderauth/roles/AgentRole.java
+++ b/src/main/java/io/jenkins/plugins/folderauth/roles/AgentRole.java
@@ -8,7 +8,6 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 @ParametersAreNonnullByDefault
 public class AgentRole extends AbstractRole {
@@ -16,29 +15,12 @@ public class AgentRole extends AbstractRole {
 
     @DataBoundConstructor
     public AgentRole(String name, Set<PermissionWrapper> permissions, Set<String> agents, Set<String> sids) {
-        super(name, permissions);
-        this.sids.addAll(sids);
-        this.agents = ConcurrentHashMap.newKeySet();
-        this.agents.addAll(agents);
+        super(name, permissions, sids);
+        this.agents = new HashSet<>(agents);
     }
 
     public AgentRole(String name, Set<PermissionWrapper> permissions, Set<String> agents) {
-        this(name, permissions, Collections.emptySet(), agents);
-    }
-
-    private AgentRole(String name, HashSet<PermissionWrapper> permissions, HashSet<String> agents, HashSet<String> sids) {
-        super(name, permissions, sids);
-        this.agents = agents;
-    }
-
-    @SuppressWarnings("unused")
-    private AgentRole writeReplace() {
-        return new AgentRole(name, new HashSet<>(permissionWrappers), new HashSet<>(agents), new HashSet<>(sids));
-    }
-
-    @SuppressWarnings("unused")
-    private AgentRole readResolve() {
-        return new AgentRole(name, permissionWrappers, agents, sids);
+        this(name, permissions, agents, Collections.emptySet());
     }
 
     @Nonnull

--- a/src/main/java/io/jenkins/plugins/folderauth/roles/FolderRole.java
+++ b/src/main/java/io/jenkins/plugins/folderauth/roles/FolderRole.java
@@ -3,13 +3,10 @@ package io.jenkins.plugins.folderauth.roles;
 import io.jenkins.plugins.folderauth.misc.PermissionWrapper;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 public class FolderRole extends AbstractRole implements Comparable<FolderRole> {
     @Nonnull
@@ -17,62 +14,16 @@ public class FolderRole extends AbstractRole implements Comparable<FolderRole> {
 
     @DataBoundConstructor
     public FolderRole(String name, Set<PermissionWrapper> permissions, Set<String> folders, Set<String> sids) {
-        super(name, permissions);
-        this.sids.addAll(sids);
-        this.folders = ConcurrentHashMap.newKeySet();
-        this.folders.addAll(folders);
+        super(name, permissions, sids);
+        this.folders = new HashSet<>(folders);
     }
 
     public FolderRole(String name, Set<PermissionWrapper> permissions, Set<String> folders) {
         this(name, permissions, folders, Collections.emptySet());
     }
 
-    private FolderRole(String name, Set<PermissionWrapper> permissions, HashSet<String> folders, HashSet<String> sids) {
-        super(name, permissions, sids);
-        this.folders = folders;
-    }
-
-    /**
-     * Used by XStream when serializing this object.
-     * <p>
-     * Simplifies the configuration produced by the object.
-     *
-     * @return a new {@link FolderRole} which does not use thread-safe constructs
-     */
-    @SuppressWarnings("unused")
-    private FolderRole writeReplace() {
-        return new FolderRole(name, permissionWrappers, new HashSet<>(folders), new HashSet<>(sids));
-    }
-
-    /**
-     * Used by XSteam when deserializing.
-     * <p>
-     * Replaces the collections into thread-safe collections.
-     *
-     * @return a new {@link FolderRole} that uses thread safe collections.
-     */
-    @SuppressWarnings("unused")
-    private FolderRole readResolve() {
-        return new FolderRole(name, permissionWrappers, folders, sids);
-    }
-
     @Override
-    public int hashCode() {
-        return Objects.hash(name, sids, permissionWrappers);
-    }
-
-    @Override
-    public boolean equals(@CheckForNull Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        FolderRole that = (FolderRole) o;
-        return name.equals(that.name) &&
-                sids.equals(that.sids) &&
-                permissionWrappers.equals(that.permissionWrappers);
-    }
-
-    @Override
-    public int compareTo(@Nonnull FolderRole other) {
+    public int compareTo(FolderRole other) {
         return name.compareTo(other.name);
     }
 

--- a/src/main/java/io/jenkins/plugins/folderauth/roles/GlobalRole.java
+++ b/src/main/java/io/jenkins/plugins/folderauth/roles/GlobalRole.java
@@ -4,7 +4,6 @@ import io.jenkins.plugins.folderauth.misc.PermissionWrapper;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -13,22 +12,8 @@ import java.util.Set;
 public class GlobalRole extends AbstractRole {
     @DataBoundConstructor
     public GlobalRole(String name, Set<PermissionWrapper> permissions, Set<String> sids) {
-        super(name, permissions);
-        this.sids.addAll(sids);
-    }
-
-    private GlobalRole(String name, HashSet<PermissionWrapper> permissions, HashSet<String> sids) {
         super(name, permissions, sids);
-    }
-
-    @SuppressWarnings("unused")
-    private GlobalRole writeReplace() {
-        return new GlobalRole(name, new HashSet<>(permissionWrappers), new HashSet<>(sids));
-    }
-
-    @SuppressWarnings("unused")
-    private GlobalRole readResolve() {
-        return new GlobalRole(name, permissionWrappers, sids);
+        this.sids.addAll(sids);
     }
 
     public GlobalRole(String name, Set<PermissionWrapper> permissions) {

--- a/src/test/java/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyAPITest.java
+++ b/src/test/java/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyAPITest.java
@@ -1,0 +1,153 @@
+package io.jenkins.plugins.folderauth;
+
+import hudson.model.Computer;
+import hudson.model.Item;
+import hudson.security.AuthorizationStrategy;
+import hudson.security.Permission;
+import io.jenkins.plugins.folderauth.roles.AgentRole;
+import io.jenkins.plugins.folderauth.roles.FolderRole;
+import io.jenkins.plugins.folderauth.roles.GlobalRole;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static io.jenkins.plugins.folderauth.misc.PermissionWrapper.wrapPermissions;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+
+
+public class FolderAuthorizationStrategyAPITest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Before
+    public void setUp() {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        FolderBasedAuthorizationStrategy strategy = new FolderBasedAuthorizationStrategy.DescriptorImpl()
+                                                        .newInstance(null, new JSONObject(true));
+        // should only create the admin global role
+        assertEquals(1, strategy.getGlobalRoles().size());
+        assertEquals(0, strategy.getFolderRoles().size());
+        assertEquals(0, strategy.getAgentRoles().size());
+
+        j.jenkins.setAuthorizationStrategy(strategy);
+    }
+
+    @Test
+    public void addGlobalRole() {
+        GlobalRole readRole = new GlobalRole("readEverything", wrapPermissions(Jenkins.READ), singleton("user1"));
+        FolderAuthorizationStrategyAPI.addGlobalRole(readRole);
+        AuthorizationStrategy a = j.jenkins.getAuthorizationStrategy();
+        assertTrue(a instanceof FolderBasedAuthorizationStrategy);
+        FolderBasedAuthorizationStrategy strategy = (FolderBasedAuthorizationStrategy) a;
+        assertTrue(strategy.getGlobalRoles().contains(readRole));
+    }
+
+    @Test
+    public void addFolderRole() {
+        FolderRole role = new FolderRole("readEverything", wrapPermissions(Jenkins.READ),
+            singleton("folder1"), singleton("user1"));
+        FolderAuthorizationStrategyAPI.addFolderRole(role);
+        AuthorizationStrategy a = j.jenkins.getAuthorizationStrategy();
+        assertTrue(a instanceof FolderBasedAuthorizationStrategy);
+        FolderBasedAuthorizationStrategy strategy = (FolderBasedAuthorizationStrategy) a;
+        assertTrue(strategy.getFolderRoles().contains(role));
+    }
+
+    @Test
+    public void addAgentRole() {
+        AgentRole role = new AgentRole("readEverything", wrapPermissions(Jenkins.READ),
+            singleton("agent1"), singleton("user1"));
+        FolderAuthorizationStrategyAPI.addAgentRole(role);
+        AuthorizationStrategy a = j.jenkins.getAuthorizationStrategy();
+        assertTrue(a instanceof FolderBasedAuthorizationStrategy);
+        FolderBasedAuthorizationStrategy strategy = (FolderBasedAuthorizationStrategy) a;
+        assertTrue(strategy.getAgentRoles().contains(role));
+    }
+
+    @Test
+    public void assignSidToGlobalRole() {
+        AuthorizationStrategy a = j.jenkins.getAuthorizationStrategy();
+        assertTrue(a instanceof FolderBasedAuthorizationStrategy);
+        FolderBasedAuthorizationStrategy oldStrategy = (FolderBasedAuthorizationStrategy) a;
+        String adminUserSid = "adminUserSid";
+        oldStrategy.getGlobalRoles().forEach(role -> assertFalse(role.getSids().contains(adminUserSid)));
+        String adminRoleName = "admin";
+        FolderAuthorizationStrategyAPI.assignSidToGlobalRole(adminUserSid, adminRoleName);
+
+        // a new authorization strategy should have been set
+        AuthorizationStrategy b = j.jenkins.getAuthorizationStrategy();
+        assertTrue(b instanceof FolderBasedAuthorizationStrategy);
+        assertNotSame("A new instance of FolderBasedAuthorizationStrategy should have been set.", a, b);
+        FolderBasedAuthorizationStrategy newStrategy = (FolderBasedAuthorizationStrategy) b;
+        GlobalRole role = newStrategy.getGlobalRoles().stream().filter(r -> r.getName().equals(adminRoleName))
+                              .findAny().orElseThrow(() -> new RuntimeException("The admin role should exist"));
+        assertTrue(role.getSids().contains(adminUserSid));
+    }
+
+    @Test
+    public void assignSidToFolderRole() {
+        String sid = "user1";
+        FolderRole role = new FolderRole("foo", wrapPermissions(Item.READ), singleton("folderFoo"));
+        assertEquals(0, role.getSids().size());
+        FolderAuthorizationStrategyAPI.addFolderRole(role);
+        FolderAuthorizationStrategyAPI.assignSidToFolderRole(sid, "foo");
+
+
+        AuthorizationStrategy a = j.jenkins.getAuthorizationStrategy();
+        assertTrue(a instanceof FolderBasedAuthorizationStrategy);
+        FolderBasedAuthorizationStrategy strategy = (FolderBasedAuthorizationStrategy) a;
+        FolderRole updatedRole = strategy.getFolderRoles().stream().filter(r -> r.getName().equals("foo"))
+                                     .findAny().orElseThrow(() -> new RuntimeException("The created role should exist"));
+        assertTrue(updatedRole.getSids().contains(sid));
+    }
+
+    @Test
+    public void assignSidToAgentRole() {
+        String sid = "user1";
+        AgentRole role = new AgentRole("bar", wrapPermissions(Item.READ), singleton("agentBar"));
+        assertEquals(0, role.getSids().size());
+        FolderAuthorizationStrategyAPI.addAgentRole(role);
+        FolderAuthorizationStrategyAPI.assignSidToAgentRole(sid, "bar");
+
+        AuthorizationStrategy a = j.jenkins.getAuthorizationStrategy();
+        assertTrue(a instanceof FolderBasedAuthorizationStrategy);
+        FolderBasedAuthorizationStrategy strategy = (FolderBasedAuthorizationStrategy) a;
+        AgentRole updatedRole = strategy.getAgentRoles().stream().filter(r -> r.getName().equals("bar"))
+                                    .findAny().orElseThrow(() -> new RuntimeException("The created role should exist"));
+        assertTrue(updatedRole.getSids().contains(sid));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowDuplicateNamesInGlobalRoles() {
+        // the "admin" role should already exist
+        FolderAuthorizationStrategyAPI.addGlobalRole(new GlobalRole("admin", wrapPermissions(Permission.READ),
+            emptySet()));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowDuplicateNamesInFolderRoles() {
+        FolderAuthorizationStrategyAPI.addFolderRole(new FolderRole("baz", wrapPermissions(Item.READ),
+            singleton("folder42")));
+        // different permissions shouldn't matter
+        FolderAuthorizationStrategyAPI.addFolderRole(new FolderRole("baz", wrapPermissions(Item.CONFIGURE),
+            singleton("folder42")));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowDuplicateNamesInAgentRoles() {
+        FolderAuthorizationStrategyAPI.addAgentRole(new AgentRole("baz", wrapPermissions(Computer.DELETE),
+            singleton("agent42")));
+        // different agent names shouldn't matter
+        FolderAuthorizationStrategyAPI.addAgentRole(new AgentRole("baz", wrapPermissions(Computer.CONFIGURE),
+            singleton("agent43")));
+    }
+}

--- a/src/test/java/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyAPITest.java
+++ b/src/test/java/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyAPITest.java
@@ -150,4 +150,23 @@ public class FolderAuthorizationStrategyAPITest {
         FolderAuthorizationStrategyAPI.addAgentRole(new AgentRole("baz", wrapPermissions(Computer.CONFIGURE),
             singleton("agent43")));
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowBlankSidInGlobalRoles() {
+        FolderAuthorizationStrategyAPI.assignSidToGlobalRole("", "admin");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowBlankSidInFolderRoles() {
+        FolderAuthorizationStrategyAPI.addFolderRole(new FolderRole("qwerty", wrapPermissions(Item.EXTENDED_READ),
+            singleton("sampleFolder")));
+        FolderAuthorizationStrategyAPI.assignSidToFolderRole(" \t", "qwerty");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowBlankSidInAgentRoles() {
+        FolderAuthorizationStrategyAPI.addFolderRole(new FolderRole("foo", wrapPermissions(Item.EXTENDED_READ),
+            singleton("sampleAgent")));
+        FolderAuthorizationStrategyAPI.assignSidToFolderRole("\t\t \t", "foo");
+    }
 }

--- a/src/test/java/io/jenkins/plugins/folderauth/FolderBasedAuthorizationStrategyTest.java
+++ b/src/test/java/io/jenkins/plugins/folderauth/FolderBasedAuthorizationStrategyTest.java
@@ -52,23 +52,23 @@ public class FolderBasedAuthorizationStrategyTest {
         final String adminRoleName = "adminRole";
         final String overallReadRoleName = "overallRead";
 
-        strategy.addGlobalRole(new GlobalRole(adminRoleName,
+        FolderAuthorizationStrategyAPI.addGlobalRole(new GlobalRole(adminRoleName,
                 wrapPermissions(FolderAuthorizationStrategyManagementLink.getSafePermissions(
                         new HashSet<>(PermissionGroup.getAll())))));
 
-        strategy.assignSidToGlobalRole(adminRoleName, "admin");
+        FolderAuthorizationStrategyAPI.assignSidToGlobalRole("admin", adminRoleName);
 
-        strategy.addGlobalRole(new GlobalRole(overallReadRoleName, wrapPermissions(Permission.READ)));
-        strategy.assignSidToGlobalRole(overallReadRoleName, "authenticated");
+        FolderAuthorizationStrategyAPI.addGlobalRole(new GlobalRole(overallReadRoleName, wrapPermissions(Permission.READ)));
+        FolderAuthorizationStrategyAPI.assignSidToGlobalRole("authenticated", overallReadRoleName);
 
-        strategy.addFolderRole(new FolderRole("folderRole1", wrapPermissions(Item.READ),
+        FolderAuthorizationStrategyAPI.addFolderRole(new FolderRole("folderRole1", wrapPermissions(Item.READ),
                 ImmutableSet.of("root")));
-        strategy.assignSidToFolderRole("folderRole1", "user1");
-        strategy.assignSidToFolderRole("folderRole1", "user2");
+        FolderAuthorizationStrategyAPI.assignSidToFolderRole("user1", "folderRole1");
+        FolderAuthorizationStrategyAPI.assignSidToFolderRole("user2", "folderRole1");
 
-        strategy.addFolderRole(new FolderRole("folderRole2", wrapPermissions(Item.CONFIGURE, Item.DELETE),
+        FolderAuthorizationStrategyAPI.addFolderRole(new FolderRole("folderRole2", wrapPermissions(Item.CONFIGURE, Item.DELETE),
                 ImmutableSet.of("root/child1")));
-        strategy.assignSidToFolderRole("folderRole2", "user2");
+        FolderAuthorizationStrategyAPI.assignSidToFolderRole("user2", "folderRole2");
 
         /*
          * Folder hierarchy for the test
@@ -90,9 +90,9 @@ public class FolderBasedAuthorizationStrategyTest {
         job1 = child2.createProject(FreeStyleProject.class, "job1");
         job2 = child3.createProject(FreeStyleProject.class, "job2");
 
-        admin = User.get("admin");
-        user1 = User.get("user1");
-        user2 = User.get("user2");
+        admin = User.getById("admin", true);
+        user1 = User.getById("user1", true);
+        user2 = User.getById("user2", true);
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/folderauth/GlobalAclImplTest.java
+++ b/src/test/java/io/jenkins/plugins/folderauth/GlobalAclImplTest.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.folderauth;
 
+import com.google.common.collect.ImmutableSet;
 import hudson.model.Item;
 import hudson.model.User;
 import io.jenkins.plugins.folderauth.acls.GlobalAclImpl;
@@ -11,6 +12,7 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import static io.jenkins.plugins.folderauth.misc.PermissionWrapper.wrapPermissions;
@@ -27,13 +29,12 @@ public class GlobalAclImplTest {
         jenkinsRule.jenkins.setSecurityRealm(jenkinsRule.createDummySecurityRealm());
         Set<GlobalRole> globalRoles = new HashSet<>();
 
-        GlobalRole role1 = new GlobalRole("role1", wrapPermissions(Item.DISCOVER, Item.READ));
-        GlobalRole role2 = new GlobalRole("role2", wrapPermissions(Item.READ, Item.CONFIGURE, Item.BUILD));
-        GlobalRole adminRole = new GlobalRole("adminRole", wrapPermissions(Jenkins.ADMINISTER));
-
-        role1.assignSids("foo", "bar", "baz");
-        role2.assignSids("baz");
-        adminRole.assignSids("admin");
+        GlobalRole role1 = new GlobalRole("role1", wrapPermissions(Item.DISCOVER, Item.READ),
+            ImmutableSet.of("foo", "bar", "baz"));
+        GlobalRole role2 = new GlobalRole("role2", wrapPermissions(Item.READ, Item.CONFIGURE, Item.BUILD),
+            ImmutableSet.of("baz"));
+        GlobalRole adminRole = new GlobalRole("adminRole", wrapPermissions(Jenkins.ADMINISTER),
+            ImmutableSet.of("admin"));
 
         globalRoles.add(role1);
         globalRoles.add(role2);
@@ -41,10 +42,10 @@ public class GlobalAclImplTest {
 
         GlobalAclImpl acl = new GlobalAclImpl(globalRoles);
 
-        Authentication foo = User.get("foo").impersonate();
-        Authentication bar = User.get("bar").impersonate();
-        Authentication baz = User.get("baz").impersonate();
-        Authentication admin = User.get("admin").impersonate();
+        Authentication foo = Objects.requireNonNull(User.getById("foo", true)).impersonate();
+        Authentication bar = Objects.requireNonNull(User.getById("bar", true)).impersonate();
+        Authentication baz = Objects.requireNonNull(User.getById("baz", true)).impersonate();
+        Authentication admin = Objects.requireNonNull(User.getById("admin", true)).impersonate();
 
         assertTrue(acl.hasPermission(foo, Item.READ));
         assertFalse(acl.hasPermission(foo, Item.CONFIGURE));

--- a/src/test/java/io/jenkins/plugins/folderauth/casc/ConfigurationWithEmptyFolderRolesTest.java
+++ b/src/test/java/io/jenkins/plugins/folderauth/casc/ConfigurationWithEmptyFolderRolesTest.java
@@ -21,6 +21,7 @@ public class ConfigurationWithEmptyFolderRolesTest {
         assertTrue(authorizationStrategy instanceof FolderBasedAuthorizationStrategy);
         FolderBasedAuthorizationStrategy strategy = (FolderBasedAuthorizationStrategy) authorizationStrategy;
         assertEquals(0, strategy.getFolderRoles().size());
+        assertEquals(0, strategy.getAgentRoles().size());
         assertEquals(2, strategy.getGlobalRoles().size());
     }
 }


### PR DESCRIPTION
This pull request follows up from where #3 left off and makes the objects of `FolderBasedAuthorizationStrategy` immutable. Making it immutable also involved making all the `AbstractRole`s immutable.

The generated serialized configuration looks like [this](https://github.com/jenkinsci/folder-auth-plugin/files/3446782/config.txt) which is exactly the same as with #3
