### PR TITLE
Allow adding roles from UI when CSRF protection is enabled

### DIFF
--- a/src/main/webapp/js/addrole.js
+++ b/src/main/webapp/js/addrole.js
@@ -93,6 +93,10 @@ const sendPostRequest = (postUrl, json) => {
     const xhr = new XMLHttpRequest();
     xhr.open('POST', postUrl, true);
     xhr.setRequestHeader('Content-Type', 'application/json');
+    // Jelly file sets up the crumb value for CSRF protection
+    if (crumb.value) {
+        xhr.setRequestHeader('Jenkins-Crumb', crumb.value);
+    }
 
     xhr.onload = () => {
         if (xhr.status === 200) {


### PR DESCRIPTION
@seanmceligot discovered that adding roles with CSRF protection enabled would throw `403 No valid crumb was included in the request`. This pull request adds the `Jenkins-Crumb` header to the POST requests for adding roles.

See https://gitter.im/jenkinsci/role-strategy-plugin?at=5d5eb1698e8dde63d81abb88