### PR TITLE
[JENKINS-59475] Add API methods to remove sids from roles

### DIFF
--- a/src/main/java/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyAPI.java
+++ b/src/main/java/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyAPI.java
@@ -236,4 +236,67 @@ public class FolderAuthorizationStrategyAPI {
             return new FolderBasedAuthorizationStrategy(strategy.getGlobalRoles(), strategy.getFolderRoles(), agentRoles);
         });
     }
+
+    /**
+     * Removes the {@code sid} from the {@link GlobalRole} with name equal to @{code roleName}.
+     *
+     * @param roleName the name of the role.
+     * @param sid      the sid that will be removed.
+     * @throws IllegalArgumentException when no {@link GlobalRole} with the given {@code roleName} exists.
+     */
+    public static void removeSidFromGlobalRole(String sid, String roleName) {
+        run(strategy -> {
+            Set<GlobalRole> globalRoles = new HashSet<>(strategy.getGlobalRoles());
+            GlobalRole role = globalRoles.stream().filter(r -> r.getName().equals(roleName)).findAny().orElseThrow(
+                () -> new IllegalArgumentException("No global role with name equal to \"" + roleName + "\" exists.")
+            );
+            Set<String> sids = new HashSet<>(role.getSids());
+            sids.remove(sid);
+            globalRoles.remove(role);
+            globalRoles.add(new GlobalRole(role.getName(), role.getPermissions(), sids));
+            return new FolderBasedAuthorizationStrategy(globalRoles, strategy.getFolderRoles(), strategy.getAgentRoles());
+        });
+    }
+
+    /**
+     * Removes the {@code sid} from the {@link FolderRole} with name equal to @{code roleName}.
+     *
+     * @param roleName the name of the role.
+     * @param sid      the sid that will be removed.
+     * @throws IllegalArgumentException when no {@link FolderRole} with the given {@code roleName} exists.
+     */
+    public static void removeSidFromFolderRole(String sid, String roleName) {
+        run(strategy -> {
+            Set<FolderRole> folderRoles = new HashSet<>(strategy.getFolderRoles());
+            FolderRole role = folderRoles.stream().filter(r -> r.getName().equals(roleName)).findAny().orElseThrow(
+                () -> new IllegalArgumentException("No folder role with name equal to \"" + roleName + "\" exists.")
+            );
+            Set<String> sids = new HashSet<>(role.getSids());
+            sids.remove(sid);
+            folderRoles.remove(role);
+            folderRoles.add(new FolderRole(role.getName(), role.getPermissions(), role.getFolderNames(), sids));
+            return new FolderBasedAuthorizationStrategy(strategy.getGlobalRoles(), folderRoles, strategy.getAgentRoles());
+        });
+    }
+
+    /**
+     * Removes the {@code sid} from the {@link AgentRole} with name equal to @{code roleName}.
+     *
+     * @param roleName the name of the role.
+     * @param sid      the sid that will be removed.
+     * @throws IllegalArgumentException when no {@link AgentRole} with the given {@code roleName} exists.
+     */
+    public static void removeSidFromAgentRole(String sid, String roleName) {
+        run(strategy -> {
+            Set<AgentRole> agentRoles = new HashSet<>(strategy.getAgentRoles());
+            AgentRole role = agentRoles.stream().filter(r -> r.getName().equals(roleName)).findAny().orElseThrow(
+                () -> new IllegalArgumentException("No agent role with name equal to \"" + roleName + "\" exists.")
+            );
+            Set<String> sids = new HashSet<>(role.getSids());
+            sids.remove(sid);
+            agentRoles.remove(role);
+            agentRoles.add(new AgentRole(role.getName(), role.getPermissions(), role.getAgents(), sids));
+            return new FolderBasedAuthorizationStrategy(strategy.getGlobalRoles(), strategy.getFolderRoles(), agentRoles);
+        });
+    }
 }

--- a/src/main/java/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyAPI.java
+++ b/src/main/java/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyAPI.java
@@ -243,6 +243,7 @@ public class FolderAuthorizationStrategyAPI {
      * @param roleName the name of the role.
      * @param sid      the sid that will be removed.
      * @throws IllegalArgumentException when no {@link GlobalRole} with the given {@code roleName} exists.
+     * @since TODO
      */
     public static void removeSidFromGlobalRole(String sid, String roleName) {
         run(strategy -> {
@@ -264,6 +265,7 @@ public class FolderAuthorizationStrategyAPI {
      * @param roleName the name of the role.
      * @param sid      the sid that will be removed.
      * @throws IllegalArgumentException when no {@link FolderRole} with the given {@code roleName} exists.
+     * @since TODO
      */
     public static void removeSidFromFolderRole(String sid, String roleName) {
         run(strategy -> {
@@ -285,6 +287,7 @@ public class FolderAuthorizationStrategyAPI {
      * @param roleName the name of the role.
      * @param sid      the sid that will be removed.
      * @throws IllegalArgumentException when no {@link AgentRole} with the given {@code roleName} exists.
+     * @since TODO
      */
     public static void removeSidFromAgentRole(String sid, String roleName) {
         run(strategy -> {

--- a/src/test/java/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyAPITest.java
+++ b/src/test/java/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyAPITest.java
@@ -141,7 +141,7 @@ public class FolderAuthorizationStrategyAPITest {
         FolderBasedAuthorizationStrategy newStrategy = (FolderBasedAuthorizationStrategy) b;
         GlobalRole role = newStrategy.getGlobalRoles().stream().filter(r -> r.getName().equals(adminRoleName))
                               .findAny().orElseThrow(() -> new RuntimeException("The admin role should exist"));
-        assertFalse(role.getSids().contains("admin2"));
+        assertFalse(role.getSids().contains("user1"));
     }
 
     @Test


### PR DESCRIPTION
Adds API methods to remove a sid from a role. This pull request does not add the capability to the UI but makes it possible to remove sids using Groovy scripts.

See: https://issues.jenkins-ci.org/browse/JENKINS-59475