### PR TITLE
Add UI method for removing SID from a role

### DIFF
--- a/src/main/java/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink.java
+++ b/src/main/java/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink.java
@@ -57,7 +57,7 @@ public class FolderAuthorizationStrategyManagementLink extends ManagementLink {
     @Override
     public String getIconFileName() {
         return Jenkins.get().getAuthorizationStrategy() instanceof FolderBasedAuthorizationStrategy ?
-            "lock.png" : null;
+                "lock.png" : null;
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink.java
+++ b/src/main/java/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink.java
@@ -57,7 +57,7 @@ public class FolderAuthorizationStrategyManagementLink extends ManagementLink {
     @Override
     public String getIconFileName() {
         return Jenkins.get().getAuthorizationStrategy() instanceof FolderBasedAuthorizationStrategy ?
-                    "lock.png" : null;
+                   "lock.png" : null;
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink.java
+++ b/src/main/java/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink.java
@@ -57,7 +57,7 @@ public class FolderAuthorizationStrategyManagementLink extends ManagementLink {
     @Override
     public String getIconFileName() {
         return Jenkins.get().getAuthorizationStrategy() instanceof FolderBasedAuthorizationStrategy ?
-                "lock.png" : null;
+                    "lock.png" : null;
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink.java
+++ b/src/main/java/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink.java
@@ -57,7 +57,7 @@ public class FolderAuthorizationStrategyManagementLink extends ManagementLink {
     @Override
     public String getIconFileName() {
         return Jenkins.get().getAuthorizationStrategy() instanceof FolderBasedAuthorizationStrategy ?
-                   "lock.png" : null;
+            "lock.png" : null;
     }
 
     /**
@@ -161,6 +161,24 @@ public class FolderAuthorizationStrategyManagementLink extends ManagementLink {
     }
 
     /**
+     * Removes {@code sid} from the global role identified by {@code roleName}.
+     *
+     * @param roleName the name of the global to which {@code sid} will be assigned to.
+     * @param sid      the sid of the user/group to be assigned.
+     * @throws IllegalStateException    when {@link Jenkins#getAuthorizationStrategy()} is
+     *                                  not {@link FolderBasedAuthorizationStrategy}
+     * @throws IllegalArgumentException when no role with name equal to {@code roleName} exists.
+     */
+    @RequirePOST
+    @Restricted(NoExternalUse.class)
+    public void doRemoveSidFromGlobalRole(@QueryParameter(required = true) String roleName,
+                                          @QueryParameter(required = true) String sid) {
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        FolderAuthorizationStrategyAPI.removeSidFromGlobalRole(sid, roleName);
+        redirect();
+    }
+
+    /**
      * Adds a {@link FolderRole} to {@link FolderBasedAuthorizationStrategy}.
      *
      * @param request the request to create the role
@@ -172,20 +190,6 @@ public class FolderAuthorizationStrategyManagementLink extends ManagementLink {
     public void doAddFolderRole(@JsonBody FolderRoleCreationRequest request) {
         Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         FolderAuthorizationStrategyAPI.addFolderRole(request.getFolderRole());
-    }
-
-    /**
-     * Adds an {@link AgentRole} to {@link FolderBasedAuthorizationStrategy}.
-     *
-     * @param request the request to create the role
-     * @throws IllegalStateException when {@link Jenkins#getAuthorizationStrategy()} is
-     *                               not {@link FolderBasedAuthorizationStrategy}
-     */
-    @RequirePOST
-    @Restricted(NoExternalUse.class)
-    public void doAddAgentRole(@JsonBody AgentRoleCreationRequest request) {
-        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
-        FolderAuthorizationStrategyAPI.addAgentRole(request.getAgentRole());
     }
 
     /**
@@ -208,6 +212,38 @@ public class FolderAuthorizationStrategyManagementLink extends ManagementLink {
     }
 
     /**
+     * Removes {@code sid} from the folder role identified by {@code roleName}.
+     *
+     * @param roleName the name of the global to which {@code sid} will be assigned to.
+     * @param sid      the sid of the user/group to be assigned.
+     * @throws IllegalStateException    when {@link Jenkins#getAuthorizationStrategy()} is
+     *                                  not {@link FolderBasedAuthorizationStrategy}
+     * @throws IllegalArgumentException when no role with name equal to {@code roleName} exists.
+     */
+    @RequirePOST
+    @Restricted(NoExternalUse.class)
+    public void doRemoveSidFromFolderRole(@QueryParameter(required = true) String roleName,
+                                          @QueryParameter(required = true) String sid) {
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        FolderAuthorizationStrategyAPI.removeSidFromFolderRole(sid, roleName);
+        redirect();
+    }
+
+    /**
+     * Adds an {@link AgentRole} to {@link FolderBasedAuthorizationStrategy}.
+     *
+     * @param request the request to create the role
+     * @throws IllegalStateException when {@link Jenkins#getAuthorizationStrategy()} is
+     *                               not {@link FolderBasedAuthorizationStrategy}
+     */
+    @RequirePOST
+    @Restricted(NoExternalUse.class)
+    public void doAddAgentRole(@JsonBody AgentRoleCreationRequest request) {
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        FolderAuthorizationStrategyAPI.addAgentRole(request.getAgentRole());
+    }
+
+    /**
      * Assigns {@code sid} to the {@link AgentRole} identified by {@code roleName}.
      * <p>
      *
@@ -223,6 +259,24 @@ public class FolderAuthorizationStrategyManagementLink extends ManagementLink {
                                        @QueryParameter(required = true) String sid) {
         Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         FolderAuthorizationStrategyAPI.assignSidToAgentRole(sid, roleName);
+        redirect();
+    }
+
+    /**
+     * Removes {@code sid} from the agent role identified by {@code roleName}.
+     *
+     * @param roleName the name of the global to which {@code sid} will be assigned to.
+     * @param sid      the sid of the user/group to be assigned.
+     * @throws IllegalStateException    when {@link Jenkins#getAuthorizationStrategy()} is
+     *                                  not {@link FolderBasedAuthorizationStrategy}
+     * @throws IllegalArgumentException when no role with name equal to {@code roleName} exists.
+     */
+    @RequirePOST
+    @Restricted(NoExternalUse.class)
+    public void doRemoveSidFromAgentRole(@QueryParameter(required = true) String roleName,
+                                         @QueryParameter(required = true) String sid) {
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        FolderAuthorizationStrategyAPI.removeSidFromAgentRole(sid, roleName);
         redirect();
     }
 

--- a/src/main/java/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink.java
+++ b/src/main/java/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink.java
@@ -141,6 +141,35 @@ public class FolderAuthorizationStrategyManagementLink extends ManagementLink {
     }
 
     /**
+     * Assigns or removes a {@code sid} to the global role identified by {@code roleName}.
+     * Does nothing if the {@code roleName} does not exist.
+     *
+     * @param roleName the name of the global role to which {@code sid} will be assigned to.
+     * @param sid      the sid of the user/group to be assigned.
+     * @param action   the action to be performed ({@code assign} or {@code remove})
+     * @throws IllegalStateException            when {@link Jenkins#getAuthorizationStrategy()} is
+     *                                          not {@link FolderBasedAuthorizationStrategy}
+     * @throws IllegalArgumentException when {@code action} is neither {@code assign} nor {@code remove}
+     */
+    @RequirePOST
+    @Restricted(NoExternalUse.class)
+    public void doAssignOrRemoveSidGlobalRole(@QueryParameter(required = true) String roleName,
+                                              @QueryParameter(required = true) String sid,
+                                              @QueryParameter(required = true) String action) {
+        switch (action) {
+            case "Assign":
+                doAssignSidToGlobalRole(roleName, sid);
+                break;
+            case "Remove":
+                doRemoveSidFromGlobalRole(roleName, sid);
+                break;
+            default:
+                throw new IllegalArgumentException("Unexpected argument action received in " +
+                    "doAssignOrRemoveSidGlobalRole: " + action);
+        }
+    }
+
+    /**
      * Assigns {@code sid} to the global role identified by {@code roleName}.
      * <p>
      * Does not do anything if a role corresponding to the {@code roleName} does not exist.
@@ -193,10 +222,39 @@ public class FolderAuthorizationStrategyManagementLink extends ManagementLink {
     }
 
     /**
+     * Assigns or removes a {@code sid} to the folder role identified by {@code roleName}.
+     * Does nothing if the {@code roleName} does not exist.
+     *
+     * @param roleName the name of the folder role to which {@code sid} will be assigned to.
+     * @param sid      the sid of the user/group to be assigned.
+     * @param action   the action to be performed ({@code assign} or {@code remove})
+     * @throws IllegalStateException            when {@link Jenkins#getAuthorizationStrategy()} is
+     *                                          not {@link FolderBasedAuthorizationStrategy}
+     * @throws IllegalArgumentException when {@code action} is neither {@code assign} nor {@code remove}
+     */
+    @RequirePOST
+    @Restricted(NoExternalUse.class)
+    public void doAssignOrRemoveSidFolderRole(@QueryParameter(required = true) String roleName,
+                                              @QueryParameter(required = true) String sid,
+                                              @QueryParameter(required = true) String action) {
+        switch (action) {
+            case "Assign":
+                doAssignSidToFolderRole(roleName, sid);
+                break;
+            case "Remove":
+                doRemoveSidFromFolderRole(roleName, sid);
+                break;
+            default:
+                throw new IllegalArgumentException("Unexpected argument action received in " +
+                    "doAssignOrRemoveSidFolderRole: " + action);
+        }
+    }
+
+    /**
      * Assigns {@code sid} to the folder role identified by {@code roleName}.
      * <p>
      *
-     * @param roleName the name of the global to which {@code sid} will be assigned to.
+     * @param roleName the name of the folder role to which {@code sid} will be assigned to.
      * @param sid      the sid of the user/group to be assigned.
      * @throws IllegalStateException            when {@link Jenkins#getAuthorizationStrategy()} is
      *                                          not {@link FolderBasedAuthorizationStrategy}
@@ -241,6 +299,35 @@ public class FolderAuthorizationStrategyManagementLink extends ManagementLink {
     public void doAddAgentRole(@JsonBody AgentRoleCreationRequest request) {
         Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         FolderAuthorizationStrategyAPI.addAgentRole(request.getAgentRole());
+    }
+
+    /**
+     * Assigns or removes a {@code sid} to the agent role identified by {@code roleName}.
+     * Does nothing if the {@code roleName} does not exist.
+     *
+     * @param roleName the name of the agent role to which {@code sid} will be assigned to.
+     * @param sid      the sid of the user/group to be assigned.
+     *                 @param action   the action to be performed ({@code assign} or {@code remove})
+     * @throws IllegalStateException            when {@link Jenkins#getAuthorizationStrategy()} is
+     *                                          not {@link FolderBasedAuthorizationStrategy}
+     * @throws IllegalArgumentException when {@code action} is neither {@code assign} nor {@code remove}
+     */
+    @RequirePOST
+    @Restricted(NoExternalUse.class)
+    public void doAssignOrRemoveSidAgentRole(@QueryParameter(required = true) String roleName,
+                                              @QueryParameter(required = true) String sid,
+                                              @QueryParameter(required = true) String action) {
+        switch (action) {
+            case "Assign":
+                doAssignSidToAgentRole(roleName, sid);
+                break;
+            case "Remove":
+                doRemoveSidFromAgentRole(roleName, sid);
+                break;
+            default:
+                throw new IllegalArgumentException("Unexpected argument action received in " +
+                    "doAssignOrRemoveSidAgentRole: " + action);
+        }
     }
 
     /**

--- a/src/main/resources/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink/index.jelly
@@ -26,26 +26,18 @@
                                 ${%name}: ${globalRole.name}
                                 <br/>
                                 ${%sids}: ${globalRole.getSidsCommaSeparated()}
-                                <form action="${rootURL}/${it.urlName}/assignSidToGlobalRole" method="POST">
+                                <form action="${rootURL}/${it.urlName}/assignOrRemoveSidGlobalRole" method="POST">
                                     <div class="form-row">
                                         <label for="assign-sid-global-${globalRole.name}" style="margin-right: 10px;">
-                                            ${%assignSid}
+                                            SID
                                         </label>
                                         <input id="assign-sid-global-input-${globalRole.name}" type="text" name="sid"/>
                                         <input type="hidden" value="${globalRole.name}" name="roleName"/>
-                                        <input id="assign-sid-global-submit-${globalRole.name}" type="submit" style="margin-left: 10px;" value="${%submit}"
-                                               class="submit"/>
-                                    </div>
-                                </form>
-                                <form action="${rootUrl}/${it.urlName}/removeSidFromGlobalRole" method="POST">
-                                    <div class="form-row">
-                                        <label for="remove-sid-global-${index}" style="margin-right: 10px;">
-                                            ${%removeSid}
-                                        </label>
-                                        <input id="remove-sid-global-input-${globalRole.name}" type="text" name="sid"/>
-                                        <input type="hidden" value="${globalRole.name}" name="roleName"/>
-                                        <input id="remove-sid-global-submit-${globalRole.name}" type="submit" style="margin-left: 10px;" value="${%submit}"
-                                                class="submit"/>
+                                        <br/>
+                                        <input id="assign-sid-global-submit-${globalRole.name}" type="submit"
+                                               style="margin-left: 40px;" value="Assign" name="action" class="submit"/>
+                                        <input id="remove-sid-global-submit-${globalRole.name}" type="submit"
+                                               style="margin-left: 10px;" value="Remove" name="action" class="submit"/>
                                     </div>
                                 </form>
                                 <br/>
@@ -124,26 +116,18 @@
                                     <br/>
                                     ${%folders}: ${folderRole.getFolderNamesCommaSeparated()}
                                     <br/>
-                                    <form action="${rootURL}/${it.urlName}/assignSidToFolderRole" method="POST">
+                                    <form action="${rootURL}/${it.urlName}/assignOrRemoveSidFolderRole" method="POST">
                                         <div class="form-row">
                                             <label for="assign-sid-folder-${folderRole.name}" style="margin-right: 10px;">
-                                                ${%assignSid}
+                                                SID
                                             </label>
-                                            <input id="assign-sid-folder-${folderRole.name}" type="text" name="sid"/>
+                                            <input id="assign-sid-folder-input-${folderRole.name}" type="text" name="sid"/>
                                             <input type="hidden" value="${folderRole.name}" name="roleName"/>
-                                            <input id="assign-sid-folder-submit-${folderRole.name}" type="submit" style="margin-left: 10px;" value="${%submit}"
-                                                   class="submit"/>
-                                        </div>
-                                    </form>
-                                    <form action="${rootUrl}/${it.urlName}/removeSidFromFolderRole" method="POST">
-                                        <div class="form-row">
-                                            <label for="remove-sid-folder-${index}" style="margin-right: 10px;">
-                                                ${%removeSid}
-                                            </label>
-                                            <input id="remove-sid-folder-input-${folderRole.name}" type="text" name="sid"/>
-                                            <input type="hidden" value="${folderRole.name}" name="roleName"/>
-                                            <input id="remove-sid-folder-submit-${folderRole.name}" type="submit" style="margin-left: 10px;" value="${%submit}"
-                                                    class="submit"/>
+                                            <br/>
+                                            <input id="assign-sid-folder-submit-${folderRole.name}" type="submit"
+                                                   style="margin-left: 40px;" value="Assign" name="action" class="submit"/>
+                                            <input id="remove-sid-folder-submit-${folderRole.name}" type="submit"
+                                                   style="margin-left: 10px;" value="Remove" name="action" class="submit"/>
                                         </div>
                                     </form>
                                     <button class="collapsible">${%viewPermissions}</button>
@@ -238,26 +222,18 @@
                                     <br/>
                                     ${%agents}: ${agentRole.getAgentNamesCommaSeparated()}
                                     <br/>
-                                    <form action="${rootURL}/${it.urlName}/assignSidToAgentRole" method="POST">
+                                    <form action="${rootURL}/${it.urlName}/assignOrRemoveSidAgentRole" method="POST">
                                         <div class="form-row">
-                                            <label for="assign-sid-agent-${index}" style="margin-right: 10px;">
-                                                ${%assignSid}
+                                            <label for="assign-sid-agent-${agentRole.name}" style="margin-right: 10px;">
+                                                SID
                                             </label>
-                                            <input id="assign-sid-agent-${agentRole.name}" type="text" name="sid"/>
+                                            <input id="assign-sid-agent-input-${agentRole.name}" type="text" name="sid"/>
                                             <input type="hidden" value="${agentRole.name}" name="roleName"/>
-                                            <input id="assign-sid-agent-submit-${agentRole.name}" type="submit" style="margin-left: 10px;" value="${%submit}"
-                                                   class="submit"/>
-                                        </div>
-                                    </form>
-                                    <form action="${rootUrl}/${it.urlName}/removeSidFromAgentRole" method="POST">
-                                        <div class="form-row">
-                                            <label for="remove-sid-agent-${index}" style="margin-right: 10px;">
-                                                ${%removeSid}
-                                            </label>
-                                            <input id="remove-sid-agent-input-${agentRole.name}" type="text" name="sid"/>
-                                            <input type="hidden" value="${agentRole.name}" name="roleName"/>
-                                            <input id="remove-sid-agent-submit-${agentRole.name}" type="submit" style="margin-left: 10px;" value="${%submit}"
-                                                    class="submit"/>
+                                            <br/>
+                                            <input id="assign-sid-agent-submit-${agentRole.name}" type="submit"
+                                                   style="margin-left: 40px;" value="Assign" name="action" class="submit"/>
+                                            <input id="remove-sid-agent-submit-${agentRole.name}" type="submit"
+                                                   style="margin-left: 10px;" value="Remove" name="action" class="submit"/>
                                         </div>
                                     </form>
                                     <button class="collapsible">${%viewPermissions}</button>

--- a/src/main/resources/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink/index.jelly
@@ -40,7 +40,6 @@
                                                style="margin-left: 10px;" value="Remove" name="action" class="submit"/>
                                     </div>
                                 </form>
-                                <br/>
                                 <button class="collapsible">${%viewPermissions}</button>
                                 <div class="collapsible-content">
                                     <ul>

--- a/src/main/resources/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink/index.jelly
@@ -22,19 +22,30 @@
                     <input type="text" placeholder="${%filterPlaceholder}" class="filter" id="globalRoleFilter"/>
                     <div class="role-container" id="globalRoleContainer">
                         <j:forEach items="${it.globalRoles}" var="globalRole" indexVar="index">
-                            <div class="role" roleName="${globalRole.name}">
+                            <div class="role" roleName="${globalRole.name}" id="global-role-${globalRole.name}">
                                 ${%name}: ${globalRole.name}
                                 <br/>
                                 ${%sids}: ${globalRole.getSidsCommaSeparated()}
                                 <form action="${rootURL}/${it.urlName}/assignSidToGlobalRole" method="POST">
                                     <div class="form-row">
-                                        <label for="assign-sid-global-${index}" style="margin-right: 10px;">
+                                        <label for="assign-sid-global-${globalRole.name}" style="margin-right: 10px;">
                                             ${%assignSid}
                                         </label>
-                                        <input id="assign-sid-global-${index}" type="text" name="sid"/>
+                                        <input id="assign-sid-global-input-${globalRole.name}" type="text" name="sid"/>
                                         <input type="hidden" value="${globalRole.name}" name="roleName"/>
-                                        <input type="submit" style="margin-left: 10px;" value="${%submit}"
+                                        <input id="assign-sid-global-submit-${globalRole.name}" type="submit" style="margin-left: 10px;" value="${%submit}"
                                                class="submit"/>
+                                    </div>
+                                </form>
+                                <form action="${rootUrl}/${it.urlName}/removeSidFromGlobalRole" method="POST">
+                                    <div class="form-row">
+                                        <label for="remove-sid-global-${index}" style="margin-right: 10px;">
+                                            ${%removeSid}
+                                        </label>
+                                        <input id="remove-sid-global-input-${globalRole.name}" type="text" name="sid"/>
+                                        <input type="hidden" value="${globalRole.name}" name="roleName"/>
+                                        <input id="remove-sid-global-submit-${globalRole.name}" type="submit" style="margin-left: 10px;" value="${%submit}"
+                                                class="submit"/>
                                     </div>
                                 </form>
                                 <br/>
@@ -77,9 +88,12 @@
                             </option>
                         </j:forEach>
                     </select>
-                    <button type="button" onclick="addGlobalRole();" class="submit-button">
-                        ${%addRole}
-                    </button>
+                    <div class="form-row">
+                        <button id="add-global-role-button" type="button" class="submit-button"
+                                onclick="addGlobalRole();">
+                            ${%addRole}
+                        </button>
+                    </div>
                 </div>
             </div>
 
@@ -112,13 +126,24 @@
                                     <br/>
                                     <form action="${rootURL}/${it.urlName}/assignSidToFolderRole" method="POST">
                                         <div class="form-row">
-                                            <label for="assign-sid-folder-${index}" style="margin-right: 10px;">
+                                            <label for="assign-sid-folder-${folderRole.name}" style="margin-right: 10px;">
                                                 ${%assignSid}
                                             </label>
-                                            <input id="assign-sid-folder-${index}" type="text" name="sid"/>
+                                            <input id="assign-sid-folder-${folderRole.name}" type="text" name="sid"/>
                                             <input type="hidden" value="${folderRole.name}" name="roleName"/>
-                                            <input type="submit" style="margin-left: 10px;" value="${%submit}"
+                                            <input id="assign-sid-folder-submit-${folderRole.name}" type="submit" style="margin-left: 10px;" value="${%submit}"
                                                    class="submit"/>
+                                        </div>
+                                    </form>
+                                    <form action="${rootUrl}/${it.urlName}/removeSidFromFolderRole" method="POST">
+                                        <div class="form-row">
+                                            <label for="remove-sid-folder-${index}" style="margin-right: 10px;">
+                                                ${%removeSid}
+                                            </label>
+                                            <input id="remove-sid-folder-input-${folderRole.name}" type="text" name="sid"/>
+                                            <input type="hidden" value="${folderRole.name}" name="roleName"/>
+                                            <input id="remove-sid-folder-submit-${folderRole.name}" type="submit" style="margin-left: 10px;" value="${%submit}"
+                                                    class="submit"/>
                                         </div>
                                     </form>
                                     <button class="collapsible">${%viewPermissions}</button>
@@ -179,7 +204,7 @@
                     </select>
                     <div class="form-row">
                         <button id="add-folder-role-button" type="button" class="submit-button"
-                                onclick="addFolderRole();" disabled="disabled">
+                                onclick="addFolderRole();">
                             ${%addRole}
                         </button>
                     </div>
@@ -218,10 +243,21 @@
                                             <label for="assign-sid-agent-${index}" style="margin-right: 10px;">
                                                 ${%assignSid}
                                             </label>
-                                            <input id="assign-sid-agent-${index}" type="text" name="sid"/>
+                                            <input id="assign-sid-agent-${agentRole.name}" type="text" name="sid"/>
                                             <input type="hidden" value="${agentRole.name}" name="roleName"/>
-                                            <input type="submit" style="margin-left: 10px;" value="${%submit}"
+                                            <input id="assign-sid-agent-submit-${agentRole.name}" type="submit" style="margin-left: 10px;" value="${%submit}"
                                                    class="submit"/>
+                                        </div>
+                                    </form>
+                                    <form action="${rootUrl}/${it.urlName}/removeSidFromAgentRole" method="POST">
+                                        <div class="form-row">
+                                            <label for="remove-sid-agent-${index}" style="margin-right: 10px;">
+                                                ${%removeSid}
+                                            </label>
+                                            <input id="remove-sid-agent-input-${agentRole.name}" type="text" name="sid"/>
+                                            <input type="hidden" value="${agentRole.name}" name="roleName"/>
+                                            <input id="remove-sid-agent-submit-${agentRole.name}" type="submit" style="margin-left: 10px;" value="${%submit}"
+                                                    class="submit"/>
                                         </div>
                                     </form>
                                     <button class="collapsible">${%viewPermissions}</button>
@@ -276,7 +312,10 @@
                         </j:forEach>
                     </select>
                     <div class="form-row">
-                        <button type="button" class="submit-button" onclick="addAgentRole();">${%addRole}</button>
+                        <button id="add-agent-role-button" type="button" class="submit-button"
+                                onclick="addAgentRole();">
+                            ${%addRole}
+                        </button>
                     </div>
                 </div>
             </div>

--- a/src/main/resources/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink/index.jelly
@@ -204,7 +204,7 @@
                     </select>
                     <div class="form-row">
                         <button id="add-folder-role-button" type="button" class="submit-button"
-                                onclick="addFolderRole();">
+                                onclick="addFolderRole();" disabled="disabled">
                             ${%addRole}
                         </button>
                     </div>

--- a/src/main/resources/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink/index.properties
+++ b/src/main/resources/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink/index.properties
@@ -5,6 +5,7 @@ currentGlobalRoles=Current Global Roles
 name=Name
 sids=SIDs
 assignSid=Assign SID
+removeSid=Remove SID
 addGlobalRole=Add a Global Role
 roleName=Name of the Role
 permissions=Permissions


### PR DESCRIPTION
Changes:
1. Added UI methods to remove Global, Folder and Agent roles in index.jelly
2. Added ids for some of the html elements - easier to get the handle of the element for UI testing (in progress)

Note:
I'm also writing a UI test for these methods as well as all the current UI methods in the `/folder-auth` page. I'll submit a separate PR when the UI test is up?
Also, I'm not very familiar with html and javascript so if you spot any mistakes let me know! thanks!