### PR TITLE
Upgrade to use jcasc test harness

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.46</version>
+        <version>3.55</version>
     </parent>
 
     <groupId>io.jenkins.plugins</groupId>
@@ -28,7 +28,7 @@
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.164.1</jenkins.version>
         <java.level>8</java.level>
-        <configuration-as-code.version>1.33</configuration-as-code.version>
+        <configuration-as-code.version>1.35</configuration-as-code.version>
     </properties>
 
     <repositories>
@@ -75,10 +75,9 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>io.jenkins</groupId>
-            <artifactId>configuration-as-code</artifactId>
+            <groupId>io.jenkins.configuration-as-code</groupId>
+            <artifactId>test-harness</artifactId>
             <version>${configuration-as-code.version}</version>
-            <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,7 @@
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
         <version>3.55</version>
+        <relativePath/>
     </parent>
 
     <groupId>io.jenkins.plugins</groupId>


### PR DESCRIPTION
JCasc had to create a new dependency that wasn't a `tests` classifier because maven doesn't allow you to bring dependencies through classifiers.

Upgrading here so that PCT works again,

Tracking:
https://github.com/jenkinsci/bom/pull/164

Note: We'll need a release for PCT please

---
Closes #46 