### PR TITLE
JENKINS-62288 Add config page explaining where to configure roles

### DIFF
--- a/src/main/resources/io/jenkins/plugins/folderauth/FolderBasedAuthorizationStrategy/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/folderauth/FolderBasedAuthorizationStrategy/config.jelly
@@ -1,7 +1,4 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
-    <f:block>
-        Roles can be configured on the 'Folder Authorization Strategy' page available from
-        <a href="${rootURL}/manage">${%Manage Jenkins}.</a>
-    </f:block>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:block>${%blurb(rootURL)}</f:block>
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/folderauth/FolderBasedAuthorizationStrategy/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/folderauth/FolderBasedAuthorizationStrategy/config.jelly
@@ -1,0 +1,7 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+    <f:block>
+        Roles can be configured on the 'Folder Authorization Strategy' page available from
+        <a href="${rootURL}/manage">${%Manage Jenkins}.</a>
+    </f:block>
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/folderauth/FolderBasedAuthorizationStrategy/config.properties
+++ b/src/main/resources/io/jenkins/plugins/folderauth/FolderBasedAuthorizationStrategy/config.properties
@@ -1,0 +1,2 @@
+blurb=Roles can be configured on the 'Folder Authorization Strategy' page available from \
+  <a href="{0}/manage">Manage Jenkins</a>.


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-62288

<details>
<summary>Before</summary>

![image](https://user-images.githubusercontent.com/21194782/82759703-f06dfb80-9de6-11ea-8c73-a2049b88977c.png)


</details>

<details>
<summary>After</summary>

![image](https://user-images.githubusercontent.com/21194782/82759677-cddbe280-9de6-11ea-868c-938649155054.png)


</details>

I didn't add a direct link as the configuration page isn't available till its been saved

WDYT?