### PR TITLE
Add category for Manage Jenkins

### DIFF
--- a/src/main/java/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink.java
+++ b/src/main/java/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink.java
@@ -83,6 +83,19 @@ public class FolderAuthorizationStrategyManagementLink extends ManagementLink {
         return Messages.FolderBasedAuthorizationStrategy_DisplayName();
     }
 
+    /**
+     * Name of the category for this management link. Exists so that plugins with core dependency pre-dating the version
+     * when this was introduced can define a category.
+     *
+     * TODO when the core version is >2.226 change this to override {@code getCategory()} instead
+     *
+     * @return name of the desired category, one of the enum values of Category, e.g. {@code STATUS}.
+     * @since 2.226
+     */
+    public String getCategoryName() {
+        return "SECURITY";
+    }
+
     @Nonnull
     @Restricted(NoExternalUse.class)
     @SuppressWarnings("unused") // used by index.jelly

--- a/src/main/java/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink.java
+++ b/src/main/java/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink.java
@@ -87,7 +87,7 @@ public class FolderAuthorizationStrategyManagementLink extends ManagementLink {
      * Name of the category for this management link. Exists so that plugins with core dependency pre-dating the version
      * when this was introduced can define a category.
      *
-     * TODO when the core version is >2.226 change this to override {@code getCategory()} instead
+     * TODO when the core version is &gt;2.226 change this to override {@code getCategory()} instead
      *
      * @return name of the desired category, one of the enum values of Category, e.g. {@code STATUS}.
      * @since 2.226


### PR DESCRIPTION
Categories were added to Jenkins core on the /manage page in 2.226

If a plugin doesn't add a category then it's in the bottom in 'Uncategorized', easy fix

<details>
<summary>Before</summary>

![folder-auth-uncategorised](https://user-images.githubusercontent.com/21194782/82790978-dffc6600-9e64-11ea-98aa-1605065041e7.png)


</details>

<details>
<summary>After</summary>

![image](https://user-images.githubusercontent.com/21194782/82790963-d8d55800-9e64-11ea-94c9-f7baf21845d3.png)


</details>