### PR TITLE
[JENKINS-74131] Extract inline JavaScript in `FolderAuthorizationStrategyManagementLink/index.jelly`

### DIFF
--- a/src/main/resources/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/folderauth/FolderAuthorizationStrategyManagementLink/index.jelly
@@ -35,10 +35,10 @@
                                         <input id="assign-sid-global-${index}" type="text"/>
                                     </div>
                                     <div class="center" style="margin-top: 5px">
-                                        <button type="button" class="submit-button" onclick="assignSid('global', ${index})">
+                                        <button type="button" class="sid-action-button submit-button" data-action="assignSid" data-index="${index}" data-role-type="global">
                                             ${%assign}
                                         </button>
-                                        <button type="button" class="submit-button" onclick="removeSid('global', ${index})">
+                                        <button type="button" class="sid-action-button submit-button" data-action="removeSid" data-index="${index}" data-role-type="global">
                                             ${%remove}
                                         </button>
                                     </div>
@@ -53,8 +53,8 @@
                                         </j:forEach>
                                     </ul>
                                 </div>
-                                <form method="POST" action="${rootURL}/${it.urlName}/deleteGlobalRole"
-                                      onsubmit="return confirm('${%confirmDelete}');">
+                                <form method="POST" action="${rootURL}/${it.urlName}/deleteGlobalRole" class="delete-role-form"
+                                      data-confirm-delete-text="${%confirmDelete}">
                                     <input type="hidden" name="roleName" value="${globalRole.name}"/>
                                     <input type="submit" value="X" class="delete-role"/>
                                 </form>
@@ -82,7 +82,7 @@
                             </option>
                         </j:forEach>
                     </select>
-                    <button type="button" onclick="addGlobalRole();" class="submit-button">
+                    <button type="button" data-action="addGlobalRole" class="add-role-button submit-button">
                         ${%addRole}
                     </button>
                 </div>
@@ -123,10 +123,10 @@
                                             <input id="assign-sid-folder-${index}" type="text" name="sid"/>
                                         </div>
                                         <div class="center" style="margin-top: 5px;">
-                                            <button type="button" class="submit-button" onclick="assignSid('folder', ${index})">
+                                            <button type="button" class="sid-action-button submit-button" data-action="assignSid" data-index="${index}" data-role-type="folder">
                                                 ${%assign}
                                             </button>
-                                            <button type="button" class="submit-button" onclick="removeSid('folder', ${index})">
+                                            <button type="button" class="sid-action-button submit-button" data-action="removeSid" data-index="${index}" data-role-type="folder">
                                                 ${%remove}
                                             </button>
                                         </div>
@@ -141,8 +141,8 @@
                                             </j:forEach>
                                         </ul>
                                     </div>
-                                    <form method="POST" action="${rootURL}/${it.urlName}/deleteFolderRole"
-                                          onsubmit="return confirm('${%confirmDelete}');">
+                                    <form method="POST" action="${rootURL}/${it.urlName}/deleteFolderRole" class="delete-role-form"
+                                          data-confirm-delete-text="${%confirmDelete}">
                                         <input type="hidden" name="roleName" value="${folderRole.name}"/>
                                         <input type="submit" value="X" class="delete-role"/>
                                     </form>
@@ -163,10 +163,6 @@
                         </label>
                     </div>
                     <div class="form-row">
-                        <script>
-                            // asynchronously render folder names
-                            getFolders();
-                        </script>
                         <label class="form-label" for="folder-select">
                             ${%applyOn}:
                         </label>
@@ -188,8 +184,8 @@
                         </j:forEach>
                     </select>
                     <div class="form-row">
-                        <button id="add-folder-role-button" type="button" class="submit-button"
-                                onclick="addFolderRole();" disabled="disabled">
+                        <button id="add-folder-role-button" type="button" class="add-role-button submit-button"
+                                data-action="addFolderRole" disabled="disabled">
                             ${%addRole}
                         </button>
                     </div>
@@ -231,10 +227,10 @@
                                             <input id="assign-sid-agent-${index}" type="text"/>
                                         </div>
                                         <div class="center" style="margin-top: 10px;">
-                                            <button type="button" class="submit-button" onclick="assignSid('agent', ${index})">
+                                            <button type="button" class="sid-action-button submit-button" data-action="assignSid" data-index="${index}" data-role-type="agent">
                                                 ${%assign}
                                             </button>
-                                            <button type="button" class="submit-button" onclick="removeSid('agent', ${index})">
+                                            <button type="button" class="sid-action-button submit-button" data-action="removeSid" data-index="${index}" data-role-type="agent">
                                                 ${%remove}
                                             </button>
                                         </div>
@@ -249,8 +245,8 @@
                                             </j:forEach>
                                         </ul>
                                     </div>
-                                    <form method="POST" action="${rootURL}/${it.urlName}/deleteAgentRole"
-                                          onsubmit="return confirm('${%confirmDelete}');">
+                                    <form method="POST" action="${rootURL}/${it.urlName}/deleteAgentRole" class="delete-role-form"
+                                          data-confirm-delete-text="${%confirmDelete}">
                                         <input type="hidden" name="roleName" value="${agentRole.name}"/>
                                         <input type="submit" value="X" class="delete-role"/>
                                     </form>
@@ -291,7 +287,7 @@
                         </j:forEach>
                     </select>
                     <div class="form-row">
-                        <button type="button" class="submit-button" onclick="addAgentRole();">${%addRole}</button>
+                        <button type="button" class="add-role-button submit-button" data-action="addAgentRole">${%addRole}</button>
                     </div>
                 </div>
             </div>

--- a/src/main/webapp/js/addrole.js
+++ b/src/main/webapp/js/addrole.js
@@ -4,7 +4,7 @@
 /**
  * Adds a global role
  */
-const addGlobalRole = () => {
+function addGlobalRole() {
     const roleName = document.getElementById('globalRoleName').value;
     if (!roleName || roleName.length < 3) {
         alert('Please enter a valid name for the role to be added.');
@@ -13,7 +13,9 @@ const addGlobalRole = () => {
 
     const response = {
         name: roleName,
-        permissions: document.getElementById('global-permission-select').getValue(),
+        permissions: Array.from(document.getElementById('global-permission-select').options)
+            .filter(option => option.selected)
+            .map(option => option.value)
     };
 
     if (response.permissions.length <= 0) {
@@ -28,7 +30,7 @@ const addGlobalRole = () => {
 /**
  * Adds a Folder Role
  */
-const addFolderRole = () => {
+function addFolderRole() {
     const roleName = document.getElementById('folderRoleName').value;
     if (!roleName || roleName.length < 3) {
         alert('Please enter a valid name for the role to be added');
@@ -37,8 +39,12 @@ const addFolderRole = () => {
 
     const response = {
         name: roleName,
-        permissions: document.getElementById('folder-permission-select').getValue(),
-        folderNames: document.getElementById('folder-select').getValue(),
+        permissions: Array.from(document.getElementById('folder-permission-select').options)
+            .filter(option => option.selected)
+            .map(option => option.value),
+        folderNames: Array.from(document.getElementById('folder-select').options)
+            .filter(option => option.selected)
+            .map(option => option.value)
     };
 
     if (!response.permissions || response.permissions.length <= 0) {
@@ -58,7 +64,7 @@ const addFolderRole = () => {
 /**
  * Adds an agent Role
  */
-const addAgentRole = () => {
+function addAgentRole() {
     const roleName = document.getElementById('agentRoleName').value;
     if (!roleName || roleName.length < 3) {
         alert('Please enter a valid name for the role to be added');
@@ -67,8 +73,12 @@ const addAgentRole = () => {
 
     const response = {
         name: roleName,
-        agentNames: document.getElementById('agent-select').getValue(),
-        permissions: document.getElementById('agent-permission-select').getValue(),
+        agentNames: Array.from(document.getElementById('agent-select').options)
+            .filter(option => option.selected)
+            .map(option => option.value),
+        permissions: Array.from(document.getElementById('agent-permission-select').options)
+            .filter(option => option.selected)
+            .map(option => option.value)
     };
 
     if (!response.permissions || response.permissions.length <= 0) {
@@ -109,3 +119,21 @@ const sendPostRequest = (postUrl, json) => {
 
     xhr.send(JSON.stringify(json));
 };
+
+document.addEventListener("DOMContentLoaded", () => {
+    document.querySelectorAll(".add-role-button").forEach((button) => {
+        button.addEventListener("click", (event) => {
+            const { action } = event.target.dataset;
+
+            window[action]();
+        });
+    });
+
+    document.querySelectorAll(".delete-role-form").forEach((form) => {
+        form.addEventListener("submit", (event) => {
+            if (!confirm(event.target.dataset.confirmDeleteText)) {
+                event.preventDefault();
+            }
+        });
+    })
+});

--- a/src/main/webapp/js/folders.js
+++ b/src/main/webapp/js/folders.js
@@ -46,3 +46,7 @@ const renderFoldersAsOptions = (folders) => {
     // enable submitting the form
     document.getElementById('add-folder-role-button').removeAttribute('disabled');
 };
+
+document.addEventListener("DOMContentLoaded", () => {
+    getFolders();
+});

--- a/src/main/webapp/js/managesids.js
+++ b/src/main/webapp/js/managesids.js
@@ -72,3 +72,15 @@ function removeSid(roleType, index) {
     request.setRequestHeader('Jenkins-Crumb', crumb.value);
     request.send(formData);
 }
+
+document.addEventListener("DOMContentLoaded", () => {
+    document.querySelectorAll(".sid-action-button").forEach((button) => {
+        button.addEventListener("click", (event) => {
+            const data = event.target.dataset;
+            const index = parseInt(data.index);
+            const { roleType, action } = data;
+
+            window[action](roleType, index);
+        });
+    })
+});


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
https://issues.jenkins.io/browse/JENKINS-74131

Along with CSP work I've also removed the calls to `getValue()`, which I assume could be leftovers from some framework that was removed.

### Testing done

[Before the change](https://www.youtube.com/watch?v=IfVN6JUQlFg)
[After the change](https://www.youtube.com/watch?v=XyDZuaKa_ZI)

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
